### PR TITLE
Fixed issue where the last custom attribute/modifier could not be deleted.

### DIFF
--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -148,7 +148,56 @@ export class ActorSheetFFG extends ActorSheet {
     if (action === "create") {
       const nk = Object.keys(attrs).length + 1;
       let newKey = document.createElement("div");
-      newKey.innerHTML = `<input type="text" name="data.attributes.attr${nk}.key" value="attr${nk}"/>`;
+      newKey.innerHTML = `<input type="text" name="data.attributes.attr${nk}.key" value="attr${nk}" style="display:none;"/><select class="attribute-modtype" name="data.attributes.attr${nk}.modtype"><option value="Characteristic">Characteristic</option></select><input class="attribute-value" type="text" name="data.attributes.attr${nk}.value" value="0" data-dtype="Number" placeholder="0"/>`;
+      form.appendChild(newKey);
+      await this._onSubmit(event);
+    }
+
+    // Remove existing attribute
+    else if (action === "delete") {
+      const li = a.closest(".attribute");
+      li.parentElement.removeChild(li);
+      await this._onSubmit(event);
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _updateObject(event, formData) {
+    // Handle the free-form attributes list
+    const formAttrs = expandObject(formData).data.attributes || {};
+    const attributes = Object.values(formAttrs).reduce((obj, v) => {
+      let k = v["key"].trim();
+      if (/[\s\.]/.test(k)) return ui.notifications.error("Attribute keys may not contain spaces or periods");
+      delete v["key"];
+      obj[k] = v;
+      return obj;
+    }, {});
+
+    // Remove attributes which are no longer used
+    if(this.object.data?.data?.attributes) {
+      for (let k of Object.keys(this.object.data.data.attributes)) {
+        if (!attributes.hasOwnProperty(k)) attributes[`-=${k}`] = null;
+      }
+    }
+
+    // Re-combine formData
+    formData = Object.entries(formData)
+      .filter((e) => !e[0].startsWith("data.attributes"))
+      .reduce(
+        (obj, e) => {
+          obj[e[0]] = e[1];
+          return obj;
+        },
+        { _id: this.object._id, "data.attributes": attributes }
+      );
+
+    // Update the Actor
+    return this.object.update(formData);
+  }
+}
+
       form.appendChild(newKey);
       await this._onSubmit(event);
     }

--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -148,7 +148,7 @@ export class ActorSheetFFG extends ActorSheet {
     if (action === "create") {
       const nk = Object.keys(attrs).length + 1;
       let newKey = document.createElement("div");
-      newKey.innerHTML = `<input type="text" name="data.attributes.attr${nk}.key" value="attr${nk}" style="display:none;"/><select class="attribute-modtype" name="data.attributes.attr${nk}.modtype"><option value="Characteristic">Characteristic</option></select><input class="attribute-value" type="text" name="data.attributes.attr${nk}.value" value="0" data-dtype="Number" placeholder="0"/>`;
+      newKey.innerHTML = `<input type="text" name="data.attributes.attr${nk}.key" value="attr${nk}"/>`;
       form.appendChild(newKey);
       await this._onSubmit(event);
     }
@@ -181,7 +181,7 @@ export class ActorSheetFFG extends ActorSheet {
   /** @override */
   _updateObject(event, formData) {
     // Handle the free-form attributes list
-    const formAttrs = expandObject(formData).data.attributes || {};
+    const formAttrs = expandObject(formData)?.data?.attributes || {};
     const attributes = Object.values(formAttrs).reduce((obj, v) => {
       let k = v["key"].trim();
       if (/[\s\.]/.test(k)) return ui.notifications.error("Attribute keys may not contain spaces or periods");

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -130,7 +130,7 @@ export class ItemSheetFFG extends ItemSheet {
     if (action === "create") {
       const nk = Object.keys(attrs).length + 1;
       let newKey = document.createElement("div");
-      newKey.innerHTML = `<input type="text" name="data.attributes.attr${nk}.key" value="attr${nk}" style="display:none;"/><select class="attribute-modtype" name="data.attributes.attr${nk}.modtype"><option value="Characteristic">Characteristic</option></select><input class="attribute-value" type="text" name="data.attributes.attr${nk}.value" value="0" data-dtype="Number" placeholder="0"/>`;
+      newKey.innerHTML = `<input type="text" name="data.attributes.attr${nk}.key" value="attr${nk}"/>`;
       form.appendChild(newKey);
       await this._onSubmit(event);
     }
@@ -148,7 +148,7 @@ export class ItemSheetFFG extends ItemSheet {
   /** @override */
   _updateObject(event, formData) {
     // Handle the free-form attributes list
-    const formAttrs = expandObject(formData).data.attributes || {};
+    const formAttrs = expandObject(formData)?.data?.attributes || {};
     const attributes = Object.values(formAttrs).reduce((obj, v) => {
       let k = v["key"].trim();
       if (/[\s\.]/.test(k)) return ui.notifications.error("Attribute keys may not contain spaces or periods");


### PR DESCRIPTION
The issue was caused by a console error blocking the save (the console error was from trying to read attributes property that did not exist when they were all removed.

Fixed the attribute/modifier add function, the way it works is, it adds a single input (just the new attribute id) then submits the form, which causes the data structure to add that record.  Then the page re-renders and displays the correct fields set up for the attribute entry based on the template html.