### PR TITLE
Fix 2-way binding.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ See our current production goals and progress [here](https://github.com/StarWars
 
 # Changelog
 
+- 16/06/2020 - Cstadther - Bug fix for 2-way binding.  
 - 16/06/2020 - Cstadther - Bug fix for #90, add talent cost in specialization tree.
 - 16/06/2020 - Cstadther - Bug fix for #97, specialization talent click display.
 - 16/06/2020 - Cstadther - Styled characteristic change dialog, and added localized values.

--- a/modules/actors/actor-ffg.js
+++ b/modules/actors/actor-ffg.js
@@ -9,6 +9,8 @@ export class ActorFFG extends Actor {
   prepareData() {
     super.prepareData();
 
+    console.debug(`Starwars FFG - Preparing Actor Data ${this.data.type}`);
+
     const actorData = this.data;
     const data = actorData.data;
     const flags = actorData.flags;
@@ -132,6 +134,7 @@ export class ActorFFG extends Actor {
       return item.type === "specialization";
     });
 
+    
     const globalTalentList = [];
     specializations.forEach((element) => {
       if (element?.talentList && element.talentList.length > 0) {
@@ -157,8 +160,6 @@ export class ActorFFG extends Actor {
         });
       }
     });
-
-    console.debug(globalTalentList);
     data.talentList = globalTalentList;
   }
 
@@ -197,4 +198,5 @@ export class ActorFFG extends Actor {
     skills = skillobject;
     return skills;
   }
+
 }

--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -36,6 +36,7 @@ export class ItemFFG extends Item {
       case "talent":
         const cleanedActivationName = data.activation.value.replace(/[\W_]+/g, "");
         const activationId = `SWFFG.TalentActivations${this._capitalize(cleanedActivationName)}`;
+
         data.activation.label = activationId;
         
         // A talent update occured, update specializations
@@ -67,7 +68,6 @@ export class ItemFFG extends Item {
                   if(!data.trees.includes(item._id)) {
                     data.trees.push(item._id);
                   }
-
                   this._updateSpecializationTalentReference(item.data.talents[talentData], itemData);
                 }
               }
@@ -183,7 +183,7 @@ export class ItemFFG extends Item {
         return item._id === specializationTalents[talent].itemId;
       });
 
-      if(gameItem) {
+      if(gameItem && !this.isOwned) {
         this._updateSpecializationTalentReference(specializationTalents[talent], gameItem);
       }
     }

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -189,7 +189,7 @@ export class ItemSheetFFG extends ItemSheet {
 
   /** @override */
   _updateObject(event, formData) {
-    console.debug(`Updating ${this.object.type}`);
+    console.debug(`Starwars FFG - Updating ${this.object.type}`);
 
     // Handle the free-form attributes list
     const formAttrs = expandObject(formData)?.data?.attributes || {};
@@ -423,7 +423,7 @@ export class ItemSheetFFG extends ItemSheet {
       $(li).find(`input[name='data.talents.${talentId}.description']`).val(itemObject.data.data.description);
       $(li).find(`input[name='data.talents.${talentId}.activation']`).val(itemObject.data.data.activation.value);
       $(li).find(`input[name='data.talents.${talentId}.activationLabel']`).val(itemObject.data.data.activation.label);
-      $(li).find(`input[name='data.talents.${talentId}.isRanked']`).val(itemObject.data.data.ranks.ranked);
+      $(li).find(`input[name='data.talents.${talentId}.isRanked']`).val(itemObject.data.data.ranks.current);
       $(li).find(`input[name='data.talents.${talentId}.itemId']`).val(itemObject.id);
       $(li).find(`input[name='data.talents.${talentId}.pack']`).val(data.pack);
 

--- a/templates/items/ffg-specialization-sheet.html
+++ b/templates/items/ffg-specialization-sheet.html
@@ -7,7 +7,7 @@
           <div class="talent-name"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize 'SWFFG.Specialization'}}" /></div>
         </div>
         <div class="talent-body">
-          <div class="popout-editor" data-target="data.description" data-label="{{item.name}} {{localize 'SWFFG.ForceBasicPower'}}">
+          <div class="popout-editor" data-target="data.description" data-label="{{item.name}}">
             {{{renderDiceTags data.description}}}
           </div>
           <!-- {{editor content=data.renderedDesc target="data.description" button=true owner=owner editable=editable}} -->
@@ -38,7 +38,7 @@
               <input class="talent-hidden" type="text" name="data.talents.{{key}}.description" value="{{talent.description}}" />
               <input class="talent-hidden" type="text" name="data.talents.{{key}}.activation" value="{{talent.activation}}" />
               <input class="talent-hidden" type="text" name="data.talents.{{key}}.itemId" value="{{talent.itemId}}" />
-              <input class="talent-hidden" type="text" name="data.talents.{{key}}.isRanked" value="{{talent.ranks.ranked}}" />
+              <input class="talent-hidden" type="text" name="data.talents.{{key}}.isRanked" value="{{talent.isRanked}}" data-dtype="Boolean" />
               <input class="talent-hidden" type="text" name="data.talents.{{key}}.pack" value="{{talent.pack}}" />
               <input class="talent-hidden" type="text" name="data.talents.{{key}}.cost" value="{{calculateSpecializationTalentCost key}}" />
             </div>


### PR DESCRIPTION
The issue being that the talents are loaded AFTER the specializations, so for owned objects this causes an issue where the actual values have not been loaded yet, and the default values in the template.json are loaded.  I've figured out how to do a single initial load on the actor-sheet-ffg.js and updated the values there.  This should almost never be an issue unless changes are being made to talents after the specialization they are associated to have been added to a character.