### PR TITLE
Fixes the popout editor from triggering when clicking embedded journal item.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See our current production goals and progress [here](https://github.com/StarWars
 
 # Changelog
 
+- 21/06/2020 - Cstadther - Bug fix #126 - Clicking embedded journal entries triggering editor also
 - 21/06/2020 - Cstadther - Bug fix #138 - CSS fix to specialization connectors
 - 20/06/2020 - Cstadther - Added additional OggDude symbol handling to enhance imported text
 - 20/06/2020 - Cstadther - Added force power import from OggDude Data Set

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -173,8 +173,15 @@ export class ItemSheetFFG extends ItemSheet {
 
       dragDrop.bind($(`form.editable.item-sheet-${this.object.data.type}`)[0]);
     }
-
-    html.find(".popout-editor").on("click", this._onPopoutEditor.bind(this));
+    
+    // hidden here instead of css to prevent non-editable display of edit button
+    html.find(".popout-editor").on("mouseover", (event) => { 
+      $(event.currentTarget).find(".popout-editor-button").show(); 
+    });
+    html.find(".popout-editor").on("mouseout", (event) => { 
+      $(event.currentTarget).find(".popout-editor-button").hide(); 
+    });
+    html.find(".popout-editor .popout-editor-button").on("click", this._onPopoutEditor.bind(this));
   }
 
   /* -------------------------------------------- */
@@ -347,7 +354,7 @@ export class ItemSheetFFG extends ItemSheet {
 
   _onPopoutEditor(event) {
     event.preventDefault();
-    const a = event.currentTarget;
+    const a = event.currentTarget.parentElement;
     const label = a.dataset.label;
     const key = a.dataset.target;
 

--- a/scss/components/_editor.scss
+++ b/scss/components/_editor.scss
@@ -198,6 +198,23 @@ span {
   height: 100%;
   width: 100%;
   min-height: 2rem;
+  position: relative;
+
+  .popout-editor-button {
+    display: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+    cursor: pointer;
+  }
+
+  // &:hover {
+  //   .popout-editor-button {
+  //     display: block;
+  //     cursor: pointer;
+  //   }
+  // }
+
 }
 
 .popout-editor-window {

--- a/styles/starwarsffg.css
+++ b/styles/starwarsffg.css
@@ -3449,6 +3449,15 @@ span.dietype.triumph {
   height: 100%;
   width: 100%;
   min-height: 2rem;
+  position: relative;
+}
+
+.starwarsffg .popout-editor .popout-editor-button {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 0;
+  cursor: pointer;
 }
 
 .starwarsffg .popout-editor-window .sheet-body {

--- a/templates/items/ffg-forcepower-sheet.html
+++ b/templates/items/ffg-forcepower-sheet.html
@@ -9,9 +9,9 @@
         </div>
         <div class="talent-body">
           <div class="popout-editor" data-target="data.description" data-label="{{item.name}} {{localize 'SWFFG.ForceBasicPower'}}">
+            <div class="popout-editor-button"><i class="fas fa-edit"></i></div>
             {{{renderDiceTags data.description}}}
           </div>
-          <!-- {{editor content=data.renderedDesc target="data.description" button=true owner=owner editable=editable}} -->
         </div>
         <div class="talent-actions">
           <a class="talent-action" data-action="edit"><i class="fas fa-edit"></i></a>
@@ -34,6 +34,7 @@
           </div>   
           <div class="talent-body">
             <div class="popout-editor" data-target="data.upgrades.{{key}}.description" data-label="{{upgrade.name}}">
+              <div class="popout-editor-button"><i class="fas fa-edit"></i></div>
               {{{renderDiceTags upgrade.description}}}
             </div>
             <input class="talent-hidden" name="data.upgrades.{{key}}.size" type="text" value="{{upgrade.size}}" data-dtype="String"/>

--- a/templates/items/ffg-shipweapon-sheet.html
+++ b/templates/items/ffg-shipweapon-sheet.html
@@ -133,6 +133,7 @@
                   <div class="block-attribute">
                     <div class="block-value block-single">
                       <div class="popout-editor" data-target="data.special.value" data-label="{{localize 'SWFFG.ItemWeaponSpecial'}}">
+                        <div class="popout-editor-button"><i class="fas fa-edit"></i></div>
                         {{{renderDiceTags data.special.value}}}
                       </div>
                   </div>

--- a/templates/items/ffg-specialization-sheet.html
+++ b/templates/items/ffg-specialization-sheet.html
@@ -8,6 +8,7 @@
         </div>
         <div class="talent-body">
           <div class="popout-editor" data-target="data.description" data-label="{{item.name}}">
+            <div class="popout-editor-button"><i class="fas fa-edit"></i></div>
             {{{renderDiceTags data.description}}}
           </div>
           <!-- {{editor content=data.renderedDesc target="data.description" button=true owner=owner editable=editable}} -->

--- a/templates/items/ffg-weapon-sheet.html
+++ b/templates/items/ffg-weapon-sheet.html
@@ -133,6 +133,7 @@
                   <div class="block-attribute">
                     <div class="block-value block-single">
                       <div class="popout-editor" data-target="data.special.value" data-label="{{localize 'SWFFG.ItemWeaponSpecial'}}">
+                        <div class="popout-editor-button"><i class="fas fa-edit"></i></div>
                         {{{renderDiceTags data.special.value}}}
                       </div>
                     </div>


### PR DESCRIPTION
fixes #126 

This changes the way the popout editor works, there will now be an edit button when hovering over a popout editor (like the normal editor).  Clicking that icon will launch the popout editor.