### PR TITLE
Added attributes obect to forcepower and specializations items

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See our current production goals and progress [here](https://github.com/StarWars
 
 # Changelog
 
+- 23/06/2020 - Cstadther - Bug fix # 155 part 2 - Added attributed to the template.json structure for forcepower and specializations
 - 23/06/2020 - Cstadther - Bug fix # 155 - Force talents from compendium do no have attributes field, until they are imported into the world from the compendium
 - 23/06/2020 - Cstadther - Bug fix # 152 - Ship silhouette size
 - 22/06/2020 - Cstadther - Added setting to disable Soak Autocalculation

--- a/template.json
+++ b/template.json
@@ -728,7 +728,8 @@
         "upgrade13": {},
         "upgrade14": {},
         "upgrade15": {}
-      }
+      },
+      "attributes": {}
     },
     "specialization": {
       "description": "",
@@ -753,7 +754,8 @@
         "talent17": {},
         "talent18": {},
         "talent19": {}
-      }
+      },
+      "attributes": {}
     }
   }
 }


### PR DESCRIPTION
second part of the fix.  This way when compendium items are imported the attributes object will be created.

fixes #155 