### PR TITLE
When weapon skill is changed to `Melee` or `Brawl` damage field is di…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ See our current production goals and progress [here](https://github.com/StarWars
 
 # Changelog
 
+- 19/07/2020 - Cstadther - Enhancement #213 - When weapon skill is changed to `Melee` or `Brawl` damage field is disabled, as base damage for those weapon types is autocalculated using brawl when owned by an actor.  Specify damage as a modifier to damage (ie +3, etc)
 - 19/07/2020 - Cstadther - Bug Fix #227 - Fixed issue with critical injuries and damage description areas not big enough.
 - 19/07/2020 - Cstadther - Bug Fix #232 - Fixed issue with minion groupskill calculations
 - 19/07/2020 - Cstadther - Bug Fix #222 - Fixed issue where soak options were not being used on Adversary Sheet.

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -284,6 +284,10 @@ export class ItemSheetFFG extends ItemSheet {
   _updateObject(event, formData) {
     CONFIG.logger.debug(`Updating ${this.object.type}`);
 
+    if (this.object.data.type === "weapon" && (formData["data.skill.value"] === "Melee" || formData["data.skill.value"] === "Brawl")) {
+      formData["data.damage.value"] = 0;
+    }
+
     // Handle the free-form attributes list
     const formAttrs = expandObject(formData)?.data?.attributes || {};
     const attributes = Object.values(formAttrs).reduce((obj, v) => {

--- a/templates/items/ffg-weapon-sheet.html
+++ b/templates/items/ffg-weapon-sheet.html
@@ -13,7 +13,7 @@
             <div class="characteristic-item flex-group-center">
               <div class="characteristic">
                 <div class="characteristic-value">
-                  <input type="text" name="data.damage.value" value="{{data.damage.value}}" data-dtype="Number" />
+                  <input type="text" name="data.damage.value" value="{{#if (or (eq data.skill.value "Brawl") (eq data.skill.value "Melee"))}}0{{else}}{{data.damage.value}}{{/if}}" data-dtype="Number" {{#if (or (eq data.skill.value "Brawl") (eq data.skill.value "Melee"))}}disabled{{/if}} />
                 </div>
               </div>
               <div class="characteristic-label">


### PR DESCRIPTION
…sabled, as base damage for those weapon types is autocalculated using brawl when owned by an actor.  Specify damage as a modifier to damage (ie +3, etc)

fixes #213 