### PR TITLE
Modifiers careerskills

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ See our current production goals and progress [here](https://github.com/StarWars
 
 # Changelog
 
+- 22/07/2020 - Cstadther - Added sheet options for Adversary for removing auto soak calculation (but only unlocks the soak field)
+- 22/07/2020 - Cstadther - Refactored character sheets using handlebar partials for skill, items, talents and force powers (shared with character and adversary sheets)
+- 22/07/2020 - Cstadther - Added modifiers for Career Skills
 - 22/07/2020 - Cstadther - Minor GroupManager fix to remove instance where groupmanager is undefined
 - 21/07/2020 - Cstadther - Specialization Talents now apply stat/skill rank/characteristic modifiers.  Importer was updated to apply stat/skill rank/characteristic modifiers for weapons/armor/gear.
 - 20/07/2020 - Cstadther - Refactored modifier part 2, fixed issue with weapon mods, added new mod (setback and career skill), updated importer to correctly populate talent and specialization characteristic and stat modifiers.

--- a/modules/actors/actor-ffg.js
+++ b/modules/actors/actor-ffg.js
@@ -373,7 +373,7 @@ export class ActorFFG extends Actor {
     Object.keys(CONFIG.FFG.characteristics).forEach((key) => {
       let total = 0;
       total += data.attributes[key].value;
-      total += ModifierHelpers.getCalculatedValueFromItems(actorData.items, key);
+      total += ModifierHelpers.getCalculatedValueFromItems(actorData.items, key, "Characteristic");
       data.characteristics[key].value = total > 7 ? 7 : total;
     });
 
@@ -384,7 +384,7 @@ export class ActorFFG extends Actor {
 
       let total = 0;
       total += data.attributes[key].value;
-      total += ModifierHelpers.getCalculatedValueFromItems(actorData.items, key);
+      total += ModifierHelpers.getCalculatedValueFromItems(actorData.items, key, "Stat");
 
       if (key === "Soak") {
         data.stats[k].value = total;
@@ -402,7 +402,12 @@ export class ActorFFG extends Actor {
     Object.keys(data.skills).forEach((key) => {
       let total = 0;
       total += data.attributes[key].value;
-      total += ModifierHelpers.getCalculatedValueFromItems(actorData.items, key);
+      total += ModifierHelpers.getCalculatedValueFromItems(actorData.items, key, "Skill Rank");
+
+      if (!data.skills[key].careerskill) {
+        data.skills[key].careerskill = ModifierHelpers.getCalculatedValueFromItems(actorData.items, key, "Career Skill");
+      }
+
       data.skills[key].rank = total > 6 ? 6 : total;
     });
   }

--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -432,7 +432,7 @@ export class ActorSheetFFG extends ActorSheet {
     if (this.object.data.type !== "vehicle") {
       // Handle characteristic updates
       Object.keys(CONFIG.FFG.characteristics).forEach((key) => {
-        let total = ModifierHelpers.getCalculateValueForAttribute(key, this.actor.data.data.attributes, this.actor.data.items);
+        let total = ModifierHelpers.getCalculateValueForAttribute(key, this.actor.data.data.attributes, this.actor.data.items, "Characteristic");
         let x = parseInt(formData[`data.characteristics.${key}.value`], 10) - total;
         let y = parseInt(formData[`data.attributes.${key}.value`], 10) + x;
         if (y > 0) {
@@ -445,7 +445,7 @@ export class ActorSheetFFG extends ActorSheet {
       Object.keys(CONFIG.FFG.character_stats).forEach((k) => {
         const key = CONFIG.FFG.character_stats[k].value;
 
-        let total = ModifierHelpers.getCalculateValueForAttribute(key, this.actor.data.data.attributes, this.actor.data.items);
+        let total = ModifierHelpers.getCalculateValueForAttribute(key, this.actor.data.data.attributes, this.actor.data.items, "Stat");
 
         let statValue = 0;
         if (key === "Soak") {
@@ -468,7 +468,7 @@ export class ActorSheetFFG extends ActorSheet {
       });
       // Handle skill rank updates
       Object.keys(this.object.data.data.skills).forEach((key) => {
-        let total = ModifierHelpers.getCalculateValueForAttribute(key, this.actor.data.data.attributes, this.actor.data.items);
+        let total = ModifierHelpers.getCalculateValueForAttribute(key, this.actor.data.data.attributes, this.actor.data.items, "Skill Rank");
         let x = parseInt(formData[`data.skills.${key}.rank`], 10) - total;
         let y = parseInt(formData[`data.attributes.${key}.value`], 10) + x;
         if (y > 0) {

--- a/modules/helpers/modifiers.js
+++ b/modules/helpers/modifiers.js
@@ -6,12 +6,12 @@ export default class ModifierHelpers {
    * @param  {array} items - Items array
    * @returns {number} - Total value of all attribute values
    */
-  static getCalculateValueForAttribute(key, attrs, items) {
+  static getCalculateValueForAttribute(key, attrs, items, modtype) {
     let total = 0;
 
     total += attrs[key].value;
 
-    total += this.getCalculatedValueFromItems(items, key);
+    total += this.getCalculatedValueFromItems(items, key, modtype);
     return total;
   }
 
@@ -20,12 +20,13 @@ export default class ModifierHelpers {
    * @param  {array} items
    * @param  {string} key
    */
-  static getCalculatedValueFromItems(items, key) {
+  static getCalculatedValueFromItems(items, key, modtype) {
     let total = 0;
+    let checked = false;
 
     items.forEach((item) => {
       const attrsToApply = Object.keys(item.data.attributes)
-        .filter((id) => item.data.attributes[id].mod === key)
+        .filter((id) => item.data.attributes[id].mod === key && item.data.attributes[id].modtype === modtype)
         .map((i) => item.data.attributes[i]);
 
       if (item.type === "armour" || item.type === "weapon") {
@@ -42,7 +43,13 @@ export default class ModifierHelpers {
           }
           if (attrsToApply.length > 0) {
             attrsToApply.forEach((attr) => {
-              total += parseInt(attr.value, 10);
+              if (modtype === "Career Skill") {
+                if (attr.value) {
+                  checked = true;
+                }
+              } else {
+                total += parseInt(attr.value, 10);
+              }
             });
           }
         }
@@ -57,16 +64,30 @@ export default class ModifierHelpers {
               },
             };
           });
-        total += this.getCalculatedValueFromItems(talents, key);
+        if (modtype === "Career Skill") {
+          if (this.getCalculatedValueFromItems(talents, key, modtype)) {
+            checked = true;
+          }
+        } else {
+          total += this.getCalculatedValueFromItems(talents, key, modtype);
+        }
       } else {
         if (attrsToApply.length > 0) {
           attrsToApply.forEach((attr) => {
-            total += parseInt(attr.value, 10);
+            if (modtype === "Career Skill") {
+              if (attr.value) {
+                checked = true;
+              }
+            } else {
+              total += parseInt(attr.value, 10);
+            }
           });
         }
       }
     });
-
+    if (modtype === "Career Skill") {
+      return checked;
+    }
     return total;
   }
 

--- a/modules/helpers/partial-templates.js
+++ b/modules/helpers/partial-templates.js
@@ -1,6 +1,6 @@
 export default class TemplateHelpers {
   static async preload() {
-    const templatePaths = ["systems/starwarsffg/templates/parts/shared/ffg-modifiers.html"];
+    const templatePaths = ["systems/starwarsffg/templates/parts/shared/ffg-modifiers.html", "systems/starwarsffg/templates/parts/actor/ffg-skills.html", "systems/starwarsffg/templates/parts/actor/ffg-weapon-armor-gear.html", "systems/starwarsffg/templates/parts/actor/ffg-talents.html", "systems/starwarsffg/templates/parts/actor/ffg-forcepowers.html"];
 
     return loadTemplates(templatePaths);
   }

--- a/templates/actors/ffg-adversary-sheet.html
+++ b/templates/actors/ffg-adversary-sheet.html
@@ -101,7 +101,7 @@
                   {{localize "SWFFG.Soak"}}
                 </div>
                 <div class="block-attribute">
-                  <div class="block-value block-single"><input type="text" name="data.stats.soak.value" value="{{data.stats.soak.value}}" data-dtype="Number" {{#if this.settings.enableSoakCalculation}}disabled{{else}}d='1'{{/if}} /></div>
+                  <div class="block-value block-single"><input type="text" name="data.stats.soak.value" value="{{data.stats.soak.value}}" data-dtype="Number" {{#if (or (eq actor.flags.config.enableAutoSoakCalculation undefined) (eq actor.flags.config.enableAutoSoakCalculation true) )}}disabled{{/if}} /></div>
                 </div>
               </div>
               <div class="block-background-shadow"></div>
@@ -166,79 +166,7 @@
         {{/each}}
       </div>
 
-      <div class="grid grid-2col skillsGrid">
-        <div class="skillTable" data-type="General">
-          <div class="pure-g skillsHeader">
-            <div class="pure-u-12-24">{{localize "SWFFG.SkillsGeneral"}}</div>
-            <div class="pure-u-4-24 hover">
-              {{localize "SWFFG.SkillsCS"}}
-              <div class="tooltip">{{localize "SWFFG.SkillsCareerSkill"}}</div>
-            </div>
-            <div class="pure-u-4-24">{{localize "SWFFG.SkillsRank"}}</div>
-            <div class="pure-u-4-24">{{localize "SWFFG.SkillsRoll"}}</div>
-          </div>
-          {{#each data.skills as |skill id|}} {{#iff skill.type '==' 'General'}}
-          <div data-ability="{{id}}" data-skilltype="{{skill.type}}" data-characteristic="{{skill.characteristic}}" class="pure-g skill">
-            <div class="pure-u-12-24">
-              {{skill.label}} {{#with (lookup ../this.FFG.characteristics [characteristic])~}} (
-              <div class="skill-characteristic" data-characteristic="{{skill.characteristic}}">{{localize abrev}}</div>
-              ) {{/with}}
-            </div>
-            <div class="pure-u-4-24 hover"><input class="careerskill-toggle" type="checkbox" name="data.skills.{{id}}.careerskill" data-dtype="Boolean" {{checked skill.careerskill}} /></div>
-            <div class="pure-u-4-24"><input class="careerskill-rank" name="data.skills.{{id}}.rank" value="{{skill.rank}}" type="text" min="0" max="6" data-dtype="Number" placeholder="0" /></div>
-            <div class="pure-u-4-24"><div class="roll-button dice-pool"></div></div>
-          </div>
-          {{/iff}} {{/each}}
-        </div>
-        <div>
-          <div class="skillTable" data-type="Combat">
-            <div class="pure-g skillsHeader">
-              <div class="pure-u-12-24">{{localize "SWFFG.SkillsCombat"}}</div>
-              <div class="pure-u-4-24 hover">
-                {{localize "SWFFG.SkillsCS"}}
-                <div class="tooltip">{{localize "SWFFG.SkillsCareerSkill"}}</div>
-              </div>
-              <div class="pure-u-4-24">{{localize "SWFFG.SkillsRank"}}</div>
-              <div class="pure-u-4-24">{{localize "SWFFG.SkillsRoll"}}</div>
-            </div>
-            {{#each data.skills as |skill id|}} {{#iff skill.type '==' 'Combat'}}
-            <div data-ability="{{id}}" data-skilltype="{{skill.type}}" data-characteristic="{{skill.characteristic}}" class="pure-g skill">
-              <div class="pure-u-12-24">
-                {{skill.label}} {{#with (lookup ../this.FFG.characteristics [characteristic])~}} (
-                <div class="skill-characteristic" data-characteristic="{{skill.characteristic}}">{{localize abrev}}</div>
-                ) {{/with}}
-              </div>
-              <div class="pure-u-4-24 hover"><input class="careerskill-toggle" type="checkbox" name="data.skills.{{id}}.careerskill" data-dtype="Boolean" {{checked skill.careerskill}} /></div>
-              <div class="pure-u-4-24"><input class="careerskill-rank" name="data.skills.{{id}}.rank" value="{{skill.rank}}" type="text" min="0" max="6" data-dtype="Number" placeholder="0" /></div>
-              <div class="pure-u-4-24"><div class="roll-button dice-pool"></div></div>
-            </div>
-            {{/iff}} {{/each}}
-          </div>
-          <div class="skillTable" data-type="Knowledge">
-            <div class="pure-g skillsHeader">
-              <div class="pure-u-15-24">{{localize "SWFFG.SkillsKnowledge"}}</div>
-              <div class="pure-u-3-24 hover">
-                {{localize "SWFFG.SkillsCS"}}
-                <div class="tooltip">{{localize "SWFFG.SkillsCareerSkill"}}</div>
-              </div>
-              <div class="pure-u-3-24">{{localize "SWFFG.SkillsRank"}}</div>
-              <div class="pure-u-3-24">{{localize "SWFFG.SkillsRoll"}}</div>
-            </div>
-            {{#each data.skills as |skill id|}} {{#iff skill.type '==' 'Knowledge'}}
-            <div data-ability="{{id}}" data-skilltype="{{skill.type}}" data-characteristic="{{skill.characteristic}}" class="pure-g skill">
-              <div class="pure-u-15-24">
-                {{skill.label}} {{#with (lookup ../this.FFG.characteristics [characteristic])~}} (
-                <div class="skill-characteristic" data-characteristic="{{skill.characteristic}}">{{localize abrev}}</div>
-                ) {{/with}}
-              </div>
-              <div class="pure-u-3-24 hover"><input class="careerskill-toggle" type="checkbox" name="data.skills.{{id}}.careerskill" data-dtype="Boolean" {{checked skill.careerskill}} /></div>
-              <div class="pure-u-3-24"><input class="careerskill-rank" name="data.skills.{{id}}.rank" value="{{skill.rank}}" type="text" min="0" max="6" data-dtype="Number" placeholder="0" /></div>
-              <div class="pure-u-3-24"><div class="roll-button dice-pool"></div></div>
-            </div>
-            {{/iff}} {{/each}}
-          </div>
-        </div>
-      </div>
+      {{> "systems/starwarsffg/templates/parts/actor/ffg-skills.html"}}
     </div>
 
     {{!-- Owned Items Tab --}}
@@ -260,94 +188,7 @@
         </div>
       </div>
 
-      {{!-- Weapons List --}}
-      <table class="items">
-        <thead>
-          <th>{{localize "SWFFG.ItemsWeapons"}}</th>
-          <th>{{localize "SWFFG.ItemsSkill"}}</th>
-          <th>{{localize "SWFFG.ItemsDamage"}}</th>
-          <th>{{localize "SWFFG.ItemsRange"}}</th>
-          <th>{{localize "SWFFG.ItemsCrit"}}</th>
-          <th>{{localize "SWFFG.ItemsEncum"}}</th>
-          <th>{{localize "SWFFG.ItemsSpecial"}}</th>
-          <th></th>
-        </thead>
-        <tbody class="items-list">
-          {{#each actor.items as |item id|}} {{#iff item.type '==' 'weapon'}}
-          <tr class="item" data-item-id="{{item._id}}">
-            <td class="item-name">{{item.name}}</td>
-            <td>{{localize (lookup ../this.FFG.combat_skills_abrev item.data.skill.value)}}</td>
-            <td>{{item.data.damage.value}}</td>
-            <td>{{localize item.data.range.label}}</td>
-            <td>{{item.data.crit.value}}</td>
-            <td>{{item.data.encumbrance.value}}</td>
-            <td>{{{renderDiceTags item.data.special.value}}}</td>
-            <td class="item-controls">
-              <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
-              <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-            </td>
-          </tr>
-          {{/iff}} {{/each}}
-        </tbody>
-      </table>
-
-      {{!-- Armour List --}}
-      <table class="items">
-        <thead>
-          <tr class="items-header">
-            <th>{{localize "SWFFG.ItemsArmor"}}</th>
-            <th>{{localize "SWFFG.ItemsDefense"}}</th>
-            <th>{{localize "SWFFG.ItemsSoak"}}</th>
-            <th>{{localize "SWFFG.ItemsHP"}}</th>
-            <th>{{localize "SWFFG.ItemsEncum"}}</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody class="items-list">
-          {{#each actor.items as |item id|}} {{#iff item.type '==' 'armour'}}
-          <tr class="item" data-item-id="{{item._id}}">
-            <td class="item-name">{{item.name}}</td>
-            <td>{{item.data.defence.value}}</td>
-            <td>{{item.data.soak.value}}</td>
-            <td>{{item.data.hardpoints.value}}</td>
-            <td>{{item.data.encumbrance.value}}</td>
-            <td class="item-controls">
-              <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
-              <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-            </td>
-          </tr>
-          {{/iff}} {{/each}}
-        </tbody>
-      </table>
-
-      {{!-- Gear List --}}
-      <table class="items">
-        <thead>
-          <tr class="items-header">
-            <th>{{localize "SWFFG.ItemsGear"}}</th>
-            <th>{{localize "SWFFG.ItemsPrice"}}</th>
-            <th>{{localize "SWFFG.ItemsRarity"}}</th>
-            <th>{{localize "SWFFG.ItemsQuantity"}}</th>
-            <th>{{localize "SWFFG.ItemsEncum"}}</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody class="items-list">
-          {{#each actor.items as |item id|}} {{#iff item.type '==' 'gear'}}
-          <tr class="item" data-item-id="{{item._id}}">
-            <td class="item-name">{{item.name}}</td>
-            <td>{{item.data.price.value}}</td>
-            <td>{{item.data.rarity.value}}</td>
-            <td>{{item.data.quantity.value}}</td>
-            <td>{{item.data.encumbrance.value}}</td>
-            <td class="item-controls">
-              <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
-              <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-            </td>
-          </tr>
-          {{/iff}} {{/each}}
-        </tbody>
-      </table>
+      {{> "systems/starwarsffg/templates/parts/actor/ffg-weapon-armor-gear.html"}}
     </div>
 
     {{!-- Talents Tab --}}
@@ -380,77 +221,7 @@
         {{/if}}
       </div>
 
-      <table class="talent-list">
-        <thead>
-          <tr>
-            <th>{{localize "SWFFG.Talents"}}</th>
-            <th>{{localize "SWFFG.TalentsActivation"}}</th>
-            <th>{{localize "SWFFG.TalentsRank"}}</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each data.talentList as |item id|}}
-          <tr class="item specialization-talent-item" data-item-id="{{item.itemId}}">
-            <td class="item-name hover">
-              {{item.name}}
-              <div class="tooltip">{{{item.safe_desc}}}</div>
-            </td>
-            <td>{{localize item.activationLabel}}</td>
-            <td>{{item.rank}}</td>
-            <td>
-              <div class="item-controls">
-                <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
-                <a class="item-control item-info" title="Item Information"><i class="fas fa-info-circle"></i></a>
-              </div>
-            </td>
-          </tr>
-          {{/each}}
-        </tbody>
-      </table>
-      {{!-- Force Powers List --}} {{#if (or (eq actor.flags.config.enableForcePool undefined) (eq actor.flags.config.enableForcePool true) )}}
-      <table class="talent-list">
-        <thead>
-          <tr>
-            <th>{{localize "SWFFG.ForcePower"}}</th>
-            <th>{{localize "SWFFG.ForcePowerUpgrades"}}</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each actor.items as |item id|}} {{#iff item.type '==' 'forcepower'}}
-          <tr class="item" data-item-id="{{item._id}}">
-            <td class="item-name hover">
-              {{item.name}}
-              <div class="tooltip">{{{item.safe_desc}}}</div>
-            </td>
-            <td>
-              <table>
-                <thead>
-                  <th>{{localize "SWFFG.SkillsName"}}</th>
-                  <th>{{localize "SWFFG.SkillsRank"}}</th>
-                </thead>
-                <tbody>
-                  {{#each item.powerUpgrades as |upgrade name|}}
-                  <tr>
-                    <td>{{upgrade.name}}</td>
-                    <td>{{upgrade.rank}}</td>
-                  </tr>
-                  {{/each}}
-                </tbody>
-              </table>
-            </td>
-            <td>
-              <div class="item-controls">
-                <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
-                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-              </div>
-            </td>
-          </tr>
-          {{/iff}} {{/each}}
-        </tbody>
-      </table>
-      {{/if}}
+      {{> "systems/starwarsffg/templates/parts/actor/ffg-talents.html"}} {{!-- Force Powers List --}} {{#if (or (eq actor.flags.config.enableForcePool undefined) (eq actor.flags.config.enableForcePool true) )}} {{> "systems/starwarsffg/templates/parts/actor/ffg-forcepowers.html"}} {{/if}}
     </div>
 
     {{!-- Biography Tab --}}

--- a/templates/actors/ffg-character-sheet.html
+++ b/templates/actors/ffg-character-sheet.html
@@ -101,7 +101,7 @@
                   {{localize "SWFFG.Soak"}}
                 </div>
                 <div class="block-attribute">
-                  <div class="block-value block-single"><input type="text" name="data.stats.soak.value" value="{{data.stats.soak.value}}" data-dtype="Number" {{#if this.settings.enableSoakCalculation}}disabled{{else}}d='1'{{/if}} /></div>
+                  <div class="block-value block-single"><input type="text" name="data.stats.soak.value" value="{{data.stats.soak.value}}" data-dtype="Number" {{#if this.settings.enableSoakCalculation}}disabled{{/if}} /></div>
                 </div>
               </div>
               <div class="block-background-shadow"></div>
@@ -166,79 +166,7 @@
         {{/each}}
       </div>
 
-      <div class="grid grid-2col skillsGrid">
-        <div class="skillTable" data-type="General">
-          <div class="pure-g skillsHeader">
-            <div class="pure-u-12-24">{{localize "SWFFG.SkillsGeneral"}}</div>
-            <div class="pure-u-3-24 hover">
-              {{localize "SWFFG.SkillsCS"}}
-              <div class="tooltip">{{localize "SWFFG.SkillsCareerSkill"}}</div>
-            </div>
-            <div class="pure-u-3-24">{{localize "SWFFG.SkillsRank"}}</div>
-            <div class="pure-u-6-24">{{localize "SWFFG.SkillsRoll"}}</div>
-          </div>
-          {{#each data.skills as |skill id|}} {{#iff skill.type '==' 'General'}}
-          <div data-ability="{{id}}" data-skilltype="{{skill.type}}" data-characteristic="{{skill.characteristic}}" class="pure-g skill">
-            <div class="pure-u-12-24">
-              {{skill.label}} {{#with (lookup ../this.FFG.characteristics [characteristic])~}} (
-              <div class="skill-characteristic" data-characteristic="{{skill.characteristic}}">{{localize abrev}}</div>
-              ) {{/with}}
-            </div>
-            <div class="pure-u-3-24 hover"><input class="careerskill-toggle" type="checkbox" name="data.skills.{{id}}.careerskill" data-dtype="Boolean" {{checked skill.careerskill}} /></div>
-            <div class="pure-u-3-24"><input class="careerskill-rank" name="data.skills.{{id}}.rank" value="{{skill.rank}}" type="text" min="0" max="6" data-dtype="Number" placeholder="0" /></div>
-            <div class="pure-u-6-24"><div class="roll-button dice-pool"></div></div>
-          </div>
-          {{/iff}} {{/each}}
-        </div>
-        <div>
-          <div class="skillTable" data-type="Combat">
-            <div class="pure-g skillsHeader">
-              <div class="pure-u-12-24">{{localize "SWFFG.SkillsCombat"}}</div>
-              <div class="pure-u-3-24 hover">
-                {{localize "SWFFG.SkillsCS"}}
-                <div class="tooltip">{{localize "SWFFG.SkillsCareerSkill"}}</div>
-              </div>
-              <div class="pure-u-3-24">{{localize "SWFFG.SkillsRank"}}</div>
-              <div class="pure-u-6-24">{{localize "SWFFG.SkillsRoll"}}</div>
-            </div>
-            {{#each data.skills as |skill id|}} {{#iff skill.type '==' 'Combat'}}
-            <div data-ability="{{id}}" data-skilltype="{{skill.type}}" data-characteristic="{{skill.characteristic}}" class="pure-g skill">
-              <div class="pure-u-12-24">
-                {{skill.label}} {{#with (lookup ../this.FFG.characteristics [characteristic])~}} (
-                <div class="skill-characteristic" data-characteristic="{{skill.characteristic}}">{{localize abrev}}</div>
-                ) {{/with}}
-              </div>
-              <div class="pure-u-3-24 hover"><input class="careerskill-toggle" type="checkbox" name="data.skills.{{id}}.careerskill" data-dtype="Boolean" {{checked skill.careerskill}} /></div>
-              <div class="pure-u-3-24"><input class="careerskill-rank" name="data.skills.{{id}}.rank" value="{{skill.rank}}" type="text" min="0" max="6" data-dtype="Number" placeholder="0" /></div>
-              <div class="pure-u-6-24"><div class="roll-button dice-pool"></div></div>
-            </div>
-            {{/iff}} {{/each}}
-          </div>
-          <div class="skillTable" data-type="Knowledge">
-            <div class="pure-g skillsHeader">
-              <div class="pure-u-12-24">{{localize "SWFFG.SkillsKnowledge"}}</div>
-              <div class="pure-u-3-24 hover">
-                {{localize "SWFFG.SkillsCS"}}
-                <div class="tooltip">{{localize "SWFFG.SkillsCareerSkill"}}</div>
-              </div>
-              <div class="pure-u-3-24">{{localize "SWFFG.SkillsRank"}}</div>
-              <div class="pure-u-6-24">{{localize "SWFFG.SkillsRoll"}}</div>
-            </div>
-            {{#each data.skills as |skill id|}} {{#iff skill.type '==' 'Knowledge'}}
-            <div data-ability="{{id}}" data-skilltype="{{skill.type}}" data-characteristic="{{skill.characteristic}}" class="pure-g skill">
-              <div class="pure-u-12-24">
-                {{skill.label}} {{#with (lookup ../this.FFG.characteristics [characteristic])~}} (
-                <div class="skill-characteristic" data-characteristic="{{skill.characteristic}}">{{localize abrev}}</div>
-                ) {{/with}}
-              </div>
-              <div class="pure-u-3-24 hover"><input class="careerskill-toggle" type="checkbox" name="data.skills.{{id}}.careerskill" data-dtype="Boolean" {{checked skill.careerskill}} /></div>
-              <div class="pure-u-3-24"><input class="careerskill-rank" name="data.skills.{{id}}.rank" value="{{skill.rank}}" type="text" min="0" max="6" data-dtype="Number" placeholder="0" /></div>
-              <div class="pure-u-6-24"><div class="roll-button dice-pool"></div></div>
-            </div>
-            {{/iff}} {{/each}}
-          </div>
-        </div>
-      </div>
+      {{> "systems/starwarsffg/templates/parts/actor/ffg-skills.html"}}
     </div>
 
     {{!-- Owned Items Tab --}}
@@ -283,110 +211,7 @@
         </div>
       </div>
 
-      {{!-- Weapons List --}}
-      <table class="items">
-        <thead>
-          <th>{{localize "SWFFG.ItemsWeapons"}}</th>
-          <th>{{localize "SWFFG.Equipped"}}</th>
-          <th>{{localize "SWFFG.ItemsSkill"}}</th>
-          <th>{{localize "SWFFG.ItemsDamage"}}</th>
-          <th>{{localize "SWFFG.ItemsRange"}}</th>
-          <th>{{localize "SWFFG.ItemsCrit"}}</th>
-          <th>{{localize "SWFFG.ItemsEncum"}}</th>
-          <th>{{localize "SWFFG.ItemsSpecial"}}</th>
-          <th></th>
-        </thead>
-        <tbody class="items-list">
-          {{#each actor.items as |item id|}} {{#iff item.type '==' 'weapon'}}
-          <tr class="item" data-item-id="{{item._id}}">
-            <td class="item-name">{{item.name}}</td>
-            <td>
-              {{#if item.data.equippable.equipped}}
-              <a class="toggle-equipped active" data-item-id="{{item._id}}" title="Equipped"><i class="fas fa-fist-raised"></i></a>
-              {{else}}
-              <a class="toggle-equipped" data-item-id="{{item._id}}" title="Equipped"><i class="fas fa-fist-raised"></i></a>
-              {{/if}}
-            </td>
-            <td>{{localize (lookup ../this.FFG.combat_skills_abrev item.data.skill.value)}}</td>
-            <td>{{item.data.damage.value}}</td>
-            <td>{{localize item.data.range.label}}</td>
-            <td>{{item.data.crit.value}}</td>
-            <td>{{item.data.encumbrance.value}}</td>
-            <td>{{{renderDiceTags item.data.special.value}}}</td>
-            <td class="item-controls">
-              <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
-              <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-            </td>
-          </tr>
-          {{/iff}} {{/each}}
-        </tbody>
-      </table>
-
-      {{!-- Armour List --}}
-      <table class="items">
-        <thead>
-          <tr class="items-header">
-            <th>{{localize "SWFFG.ItemsArmor"}}</th>
-            <th>{{localize "SWFFG.Equipped"}}</th>
-            <th>{{localize "SWFFG.ItemsDefense"}}</th>
-            <th>{{localize "SWFFG.ItemsSoak"}}</th>
-            <th>{{localize "SWFFG.ItemsHP"}}</th>
-            <th>{{localize "SWFFG.ItemsEncum"}}</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody class="items-list">
-          {{#each actor.items as |item id|}} {{#iff item.type '==' 'armour'}}
-          <tr class="item" data-item-id="{{item._id}}">
-            <td class="item-name">{{item.name}}</td>
-            <td>
-              {{#if item.data.equippable.equipped}}
-              <a class="toggle-equipped active" data-item-id="{{item._id}}" title="Equipped"><i class="fas fa-shield-alt"></i></a>
-              {{else}}
-              <a class="toggle-equipped" data-item-id="{{item._id}}" title="Equipped"><i class="fas fa-shield-alt"></i></a>
-              {{/if}}
-            </td>
-            <td>{{item.data.defence.value}}</td>
-            <td>{{item.data.soak.value}}</td>
-            <td>{{item.data.hardpoints.value}}</td>
-            <td>{{item.data.encumbrance.value}}</td>
-            <td class="item-controls">
-              <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
-              <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-            </td>
-          </tr>
-          {{/iff}} {{/each}}
-        </tbody>
-      </table>
-
-      {{!-- Gear List --}}
-      <table class="items">
-        <thead>
-          <tr class="items-header">
-            <th>{{localize "SWFFG.ItemsGear"}}</th>
-            <th>{{localize "SWFFG.ItemsPrice"}}</th>
-            <th>{{localize "SWFFG.ItemsRarity"}}</th>
-            <th>{{localize "SWFFG.ItemsQuantity"}}</th>
-            <th>{{localize "SWFFG.ItemsEncum"}}</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody class="items-list">
-          {{#each actor.items as |item id|}} {{#iff item.type '==' 'gear'}}
-          <tr class="item" data-item-id="{{item._id}}">
-            <td class="item-name">{{item.name}}</td>
-            <td>{{item.data.price.value}}</td>
-            <td>{{item.data.rarity.value}}</td>
-            <td>{{item.data.quantity.value}}</td>
-            <td>{{item.data.encumbrance.value}}</td>
-            <td class="item-controls">
-              <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
-              <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-            </td>
-          </tr>
-          {{/iff}} {{/each}}
-        </tbody>
-      </table>
+      {{> "systems/starwarsffg/templates/parts/actor/ffg-weapon-armor-gear.html"}}
     </div>
 
     {{!-- Talents Tab --}}
@@ -419,77 +244,7 @@
         {{/if}}
       </div>
 
-      <table class="talent-list">
-        <thead>
-          <tr>
-            <th>{{localize "SWFFG.Talents"}}</th>
-            <th>{{localize "SWFFG.TalentsActivation"}}</th>
-            <th>{{localize "SWFFG.TalentsRank"}}</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each data.talentList as |item id|}}
-          <tr class="item specialization-talent-item" data-item-id="{{item.itemId}}">
-            <td class="item-name hover">
-              {{item.name}}
-              <div class="tooltip">{{{item.safe_desc}}}</div>
-            </td>
-            <td>{{localize item.activationLabel}}</td>
-            <td>{{item.rank}}</td>
-            <td>
-              <div class="item-controls">
-                <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
-                <a class="item-control item-info" title="Item Information"><i class="fas fa-info-circle"></i></a>
-              </div>
-            </td>
-          </tr>
-          {{/each}}
-        </tbody>
-      </table>
-      {{!-- Force Powers List --}} {{#if (or (eq actor.flags.config.enableForcePool undefined) (eq actor.flags.config.enableForcePool true) )}}
-      <table class="talent-list">
-        <thead>
-          <tr>
-            <th>{{localize "SWFFG.ForcePower"}}</th>
-            <th>{{localize "SWFFG.ForcePowerUpgrades"}}</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each actor.items as |item id|}} {{#iff item.type '==' 'forcepower'}}
-          <tr class="item" data-item-id="{{item._id}}">
-            <td class="item-name hover">
-              {{item.name}}
-              <div class="tooltip">{{{item.safe_desc}}}</div>
-            </td>
-            <td>
-              <table>
-                <thead>
-                  <th>{{localize "SWFFG.SkillsName"}}</th>
-                  <th>{{localize "SWFFG.SkillsRank"}}</th>
-                </thead>
-                <tbody>
-                  {{#each item.powerUpgrades as |upgrade name|}}
-                  <tr>
-                    <td>{{upgrade.name}}</td>
-                    <td>{{upgrade.rank}}</td>
-                  </tr>
-                  {{/each}}
-                </tbody>
-              </table>
-            </td>
-            <td>
-              <div class="item-controls">
-                <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
-                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-              </div>
-            </td>
-          </tr>
-          {{/iff}} {{/each}}
-        </tbody>
-      </table>
-      {{/if}}
+      {{> "systems/starwarsffg/templates/parts/actor/ffg-talents.html"}} {{!-- Force Powers List --}} {{#if (or (eq actor.flags.config.enableForcePool undefined) (eq actor.flags.config.enableForcePool true) )}} {{> "systems/starwarsffg/templates/parts/actor/ffg-forcepowers.html"}} {{/if}}
     </div>
 
     {{!-- Biography Tab --}}

--- a/templates/parts/actor/ffg-forcepowers.html
+++ b/templates/parts/actor/ffg-forcepowers.html
@@ -1,0 +1,41 @@
+<table class="talent-list">
+  <thead>
+    <tr>
+      <th>{{localize "SWFFG.ForcePower"}}</th>
+      <th>{{localize "SWFFG.ForcePowerUpgrades"}}</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each actor.items as |item id|}} {{#iff item.type '==' 'forcepower'}}
+    <tr class="item" data-item-id="{{item._id}}">
+      <td class="item-name hover">
+        {{item.name}}
+        <div class="tooltip">{{{item.safe_desc}}}</div>
+      </td>
+      <td>
+        <table>
+          <thead>
+            <th>{{localize "SWFFG.SkillsName"}}</th>
+            <th>{{localize "SWFFG.SkillsRank"}}</th>
+          </thead>
+          <tbody>
+            {{#each item.powerUpgrades as |upgrade name|}}
+            <tr>
+              <td>{{upgrade.name}}</td>
+              <td>{{upgrade.rank}}</td>
+            </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </td>
+      <td>
+        <div class="item-controls">
+          <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
+          <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+        </div>
+      </td>
+    </tr>
+    {{/iff}} {{/each}}
+  </tbody>
+</table>

--- a/templates/parts/actor/ffg-skills.html
+++ b/templates/parts/actor/ffg-skills.html
@@ -1,0 +1,73 @@
+<div class="grid grid-2col skillsGrid">
+  <div class="skillTable" data-type="General">
+    <div class="pure-g skillsHeader">
+      <div class="pure-u-12-24">{{localize "SWFFG.SkillsGeneral"}}</div>
+      <div class="pure-u-3-24 hover">
+        {{localize "SWFFG.SkillsCS"}}
+        <div class="tooltip">{{localize "SWFFG.SkillsCareerSkill"}}</div>
+      </div>
+      <div class="pure-u-3-24">{{localize "SWFFG.SkillsRank"}}</div>
+      <div class="pure-u-6-24">{{localize "SWFFG.SkillsRoll"}}</div>
+    </div>
+    {{#each data.skills as |skill id|}} {{#iff skill.type '==' 'General'}}
+    <div data-ability="{{id}}" data-skilltype="{{skill.type}}" data-characteristic="{{skill.characteristic}}" class="pure-g skill">
+      <div class="pure-u-12-24">
+        {{skill.label}} {{#with (lookup ../this.FFG.characteristics [characteristic])~}} (
+        <div class="skill-characteristic" data-characteristic="{{skill.characteristic}}">{{localize abrev}}</div>
+        ) {{/with}}
+      </div>
+      <div class="pure-u-3-24 hover"><input class="careerskill-toggle" type="checkbox" name="data.skills.{{id}}.careerskill" data-dtype="Boolean" {{checked skill.careerskill}} /></div>
+      <div class="pure-u-3-24"><input class="careerskill-rank" name="data.skills.{{id}}.rank" value="{{skill.rank}}" type="text" min="0" max="6" data-dtype="Number" placeholder="0" /></div>
+      <div class="pure-u-6-24"><div class="roll-button dice-pool"></div></div>
+    </div>
+    {{/iff}} {{/each}}
+  </div>
+  <div>
+    <div class="skillTable" data-type="Combat">
+      <div class="pure-g skillsHeader">
+        <div class="pure-u-12-24">{{localize "SWFFG.SkillsCombat"}}</div>
+        <div class="pure-u-3-24 hover">
+          {{localize "SWFFG.SkillsCS"}}
+          <div class="tooltip">{{localize "SWFFG.SkillsCareerSkill"}}</div>
+        </div>
+        <div class="pure-u-3-24">{{localize "SWFFG.SkillsRank"}}</div>
+        <div class="pure-u-6-24">{{localize "SWFFG.SkillsRoll"}}</div>
+      </div>
+      {{#each data.skills as |skill id|}} {{#iff skill.type '==' 'Combat'}}
+      <div data-ability="{{id}}" data-skilltype="{{skill.type}}" data-characteristic="{{skill.characteristic}}" class="pure-g skill">
+        <div class="pure-u-12-24">
+          {{skill.label}} {{#with (lookup ../this.FFG.characteristics [characteristic])~}} (
+          <div class="skill-characteristic" data-characteristic="{{skill.characteristic}}">{{localize abrev}}</div>
+          ) {{/with}}
+        </div>
+        <div class="pure-u-3-24 hover"><input class="careerskill-toggle" type="checkbox" name="data.skills.{{id}}.careerskill" data-dtype="Boolean" {{checked skill.careerskill}} /></div>
+        <div class="pure-u-3-24"><input class="careerskill-rank" name="data.skills.{{id}}.rank" value="{{skill.rank}}" type="text" min="0" max="6" data-dtype="Number" placeholder="0" /></div>
+        <div class="pure-u-6-24"><div class="roll-button dice-pool"></div></div>
+      </div>
+      {{/iff}} {{/each}}
+    </div>
+    <div class="skillTable" data-type="Knowledge">
+      <div class="pure-g skillsHeader">
+        <div class="pure-u-12-24">{{localize "SWFFG.SkillsKnowledge"}}</div>
+        <div class="pure-u-3-24 hover">
+          {{localize "SWFFG.SkillsCS"}}
+          <div class="tooltip">{{localize "SWFFG.SkillsCareerSkill"}}</div>
+        </div>
+        <div class="pure-u-3-24">{{localize "SWFFG.SkillsRank"}}</div>
+        <div class="pure-u-6-24">{{localize "SWFFG.SkillsRoll"}}</div>
+      </div>
+      {{#each data.skills as |skill id|}} {{#iff skill.type '==' 'Knowledge'}}
+      <div data-ability="{{id}}" data-skilltype="{{skill.type}}" data-characteristic="{{skill.characteristic}}" class="pure-g skill">
+        <div class="pure-u-12-24">
+          {{skill.label}} {{#with (lookup ../this.FFG.characteristics [characteristic])~}} (
+          <div class="skill-characteristic" data-characteristic="{{skill.characteristic}}">{{localize abrev}}</div>
+          ) {{/with}}
+        </div>
+        <div class="pure-u-3-24 hover"><input class="careerskill-toggle" type="checkbox" name="data.skills.{{id}}.careerskill" data-dtype="Boolean" {{checked skill.careerskill}} /></div>
+        <div class="pure-u-3-24"><input class="careerskill-rank" name="data.skills.{{id}}.rank" value="{{skill.rank}}" type="text" min="0" max="6" data-dtype="Number" placeholder="0" /></div>
+        <div class="pure-u-6-24"><div class="roll-button dice-pool"></div></div>
+      </div>
+      {{/iff}} {{/each}}
+    </div>
+  </div>
+</div>

--- a/templates/parts/actor/ffg-talents.html
+++ b/templates/parts/actor/ffg-talents.html
@@ -1,0 +1,28 @@
+<table class="talent-list">
+  <thead>
+    <tr>
+      <th>{{localize "SWFFG.Talents"}}</th>
+      <th>{{localize "SWFFG.TalentsActivation"}}</th>
+      <th>{{localize "SWFFG.TalentsRank"}}</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each data.talentList as |item id|}}
+    <tr class="item specialization-talent-item" data-item-id="{{item.itemId}}">
+      <td class="item-name hover">
+        {{item.name}}
+        <div class="tooltip">{{{item.safe_desc}}}</div>
+      </td>
+      <td>{{localize item.activationLabel}}</td>
+      <td>{{item.rank}}</td>
+      <td>
+        <div class="item-controls">
+          <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
+          <a class="item-control item-info" title="Item Information"><i class="fas fa-info-circle"></i></a>
+        </div>
+      </td>
+    </tr>
+    {{/each}}
+  </tbody>
+</table>

--- a/templates/parts/actor/ffg-weapon-armor-gear.html
+++ b/templates/parts/actor/ffg-weapon-armor-gear.html
@@ -1,0 +1,104 @@
+{{!-- Weapons List --}}
+<table class="items">
+  <thead>
+    <th>{{localize "SWFFG.ItemsWeapons"}}</th>
+    <th>{{localize "SWFFG.Equipped"}}</th>
+    <th>{{localize "SWFFG.ItemsSkill"}}</th>
+    <th>{{localize "SWFFG.ItemsDamage"}}</th>
+    <th>{{localize "SWFFG.ItemsRange"}}</th>
+    <th>{{localize "SWFFG.ItemsCrit"}}</th>
+    <th>{{localize "SWFFG.ItemsEncum"}}</th>
+    <th>{{localize "SWFFG.ItemsSpecial"}}</th>
+    <th></th>
+  </thead>
+  <tbody class="items-list">
+    {{#each actor.items as |item id|}} {{#iff item.type '==' 'weapon'}}
+    <tr class="item" data-item-id="{{item._id}}">
+      <td class="item-name">{{item.name}}</td>
+      <td>
+        {{#if item.data.equippable.equipped}}
+        <a class="toggle-equipped active" data-item-id="{{item._id}}" title="Equipped"><i class="fas fa-fist-raised"></i></a>
+        {{else}}
+        <a class="toggle-equipped" data-item-id="{{item._id}}" title="Equipped"><i class="fas fa-fist-raised"></i></a>
+        {{/if}}
+      </td>
+      <td>{{localize (lookup ../this.FFG.combat_skills_abrev item.data.skill.value)}}</td>
+      <td>{{item.data.damage.value}}</td>
+      <td>{{localize item.data.range.label}}</td>
+      <td>{{item.data.crit.value}}</td>
+      <td>{{item.data.encumbrance.value}}</td>
+      <td>{{{renderDiceTags item.data.special.value}}}</td>
+      <td class="item-controls">
+        <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
+        <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+      </td>
+    </tr>
+    {{/iff}} {{/each}}
+  </tbody>
+</table>
+
+{{!-- Armour List --}}
+<table class="items">
+  <thead>
+    <tr class="items-header">
+      <th>{{localize "SWFFG.ItemsArmor"}}</th>
+      <th>{{localize "SWFFG.Equipped"}}</th>
+      <th>{{localize "SWFFG.ItemsDefense"}}</th>
+      <th>{{localize "SWFFG.ItemsSoak"}}</th>
+      <th>{{localize "SWFFG.ItemsHP"}}</th>
+      <th>{{localize "SWFFG.ItemsEncum"}}</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody class="items-list">
+    {{#each actor.items as |item id|}} {{#iff item.type '==' 'armour'}}
+    <tr class="item" data-item-id="{{item._id}}">
+      <td class="item-name">{{item.name}}</td>
+      <td>
+        {{#if item.data.equippable.equipped}}
+        <a class="toggle-equipped active" data-item-id="{{item._id}}" title="Equipped"><i class="fas fa-shield-alt"></i></a>
+        {{else}}
+        <a class="toggle-equipped" data-item-id="{{item._id}}" title="Equipped"><i class="fas fa-shield-alt"></i></a>
+        {{/if}}
+      </td>
+      <td>{{item.data.defence.value}}</td>
+      <td>{{item.data.soak.value}}</td>
+      <td>{{item.data.hardpoints.value}}</td>
+      <td>{{item.data.encumbrance.value}}</td>
+      <td class="item-controls">
+        <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
+        <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+      </td>
+    </tr>
+    {{/iff}} {{/each}}
+  </tbody>
+</table>
+
+{{!-- Gear List --}}
+<table class="items">
+  <thead>
+    <tr class="items-header">
+      <th>{{localize "SWFFG.ItemsGear"}}</th>
+      <th>{{localize "SWFFG.ItemsPrice"}}</th>
+      <th>{{localize "SWFFG.ItemsRarity"}}</th>
+      <th>{{localize "SWFFG.ItemsQuantity"}}</th>
+      <th>{{localize "SWFFG.ItemsEncum"}}</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody class="items-list">
+    {{#each actor.items as |item id|}} {{#iff item.type '==' 'gear'}}
+    <tr class="item" data-item-id="{{item._id}}">
+      <td class="item-name">{{item.name}}</td>
+      <td>{{item.data.price.value}}</td>
+      <td>{{item.data.rarity.value}}</td>
+      <td>{{item.data.quantity.value}}</td>
+      <td>{{item.data.encumbrance.value}}</td>
+      <td class="item-controls">
+        <!-- <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a> -->
+        <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+      </td>
+    </tr>
+    {{/iff}} {{/each}}
+  </tbody>
+</table>

--- a/templates/parts/shared/ffg-modifiers.html
+++ b/templates/parts/shared/ffg-modifiers.html
@@ -24,7 +24,11 @@
       <option value="{{t.value}}">{{localize t.label}}</option>
       {{/each}} {{/if}} {{/select}}
     </select>
+    {{#if (eq attr.modtype "Career Skill")}}
+    <input class="attribute-value" type="checkbox" name="data.attributes.{{key}}.value" data-dtype="Boolean" checked />
+    {{else}}
     <input class="attribute-value" type="text" name="data.attributes.{{key}}.value" value="{{attr.value}}" data-dtype="{{attr.dtype}}" placeholder="0" />
+    {{/if}}
     <a class="attribute-control" data-action="delete"><i class="fas fa-trash"></i></a>
   </li>
   {{/each}}


### PR DESCRIPTION
Added modifiers for Career Skills
Refactored character sheets using handlebar partials for skill, items, talents and force powers (shared with character and adversary sheets)
Added sheet options for Adversary for removing auto soak calculation (but only unlocks the soak field)

fixes #248 