### PR TITLE
Fix #162 and editor not displaying text in items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ See our current production goals and progress [here](https://github.com/StarWars
 
 # Changelog
 
+- 24/09/2020 - Cstadther - Fix #162 and editor not displaying text in items.
 - 24/09/2020 - Cstadther - Moved dice pool rendering so `Observer` players can see the rendered dice pool on sheets.
 - 23/09/2020 - Cstadther - Re-added missing modifier display css for sheets.
 - 22/09/2020 - Cstadther - Refactor CSS did not change styles, but remove duplicates and cleaned up unused styles.

--- a/scss/components/_itemsheet_base.scss
+++ b/scss/components/_itemsheet_base.scss
@@ -4,7 +4,9 @@
       height: 50px;
       width: 215px;
     }
-
+    .tab[data-tab].active {
+      height:100%;
+    }
     .tabs {
       height : 20px;
       border: 0;

--- a/styles/starwarsffg.css
+++ b/styles/starwarsffg.css
@@ -440,6 +440,10 @@ img {
   width: 215px;
 }
 
+.starwarsffg.sheet.item .tab[data-tab].active {
+  height: 100%;
+}
+
 .starwarsffg.sheet.item .tabs {
   height: 20px;
   border: 0;


### PR DESCRIPTION
CSS fix for item text not being displayed in editor correctly.
This also Fixes #162