### PR TITLE
Updated padding on block-title css so that long translations will fit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ See our current production goals and progress [here](https://github.com/StarWars
 
 # Changelog
 
+- 24/09/2020 - Cstadther - Updated padding on block-title css so that long translations will fit correctly.
 - 24/09/2020 - Cstadther - Fix #162 and editor not displaying text in items.
 - 24/09/2020 - Cstadther - Moved dice pool rendering so `Observer` players can see the rendered dice pool on sheets.
 - 23/09/2020 - Cstadther - Re-added missing modifier display css for sheets.

--- a/scss/components/_sheet_base.scss
+++ b/scss/components/_sheet_base.scss
@@ -96,6 +96,7 @@
     background-color: rgb(85, 49, 19);
     color: white;
     font-size: 13px;
+    padding: 0 10px;
     text-transform: uppercase;
     margin:auto;
     

--- a/styles/starwarsffg.css
+++ b/styles/starwarsffg.css
@@ -547,6 +547,7 @@ img {
   background-color: #553113;
   color: white;
   font-size: 13px;
+  padding: 0 10px;
   text-transform: uppercase;
   margin: auto;
   --notchSize: 8px;


### PR DESCRIPTION
… correctly.

kinda fixes #42, doesn't have dynamic text sizing, but blocks now expand correctly and have enough padding to display whole title.