### PR TITLE
Fixed issue with migrating soak from 0.5 to 1.0 schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ See our current production goals and progress [here](https://github.com/StarWars
 
 # Changelog
 
+- 03/10/2020 - Cstadther - Fixed issue with migrating soak from 0.5 to 1.0 schema, fixed issue with soak calculation if auto calculation is turned off then on, removed adding willpower or brawn modifiers to Wound and Strain calculations.
 - 02/10/2020 - Cstadther - Fix File Uploads, 0.7.3 now requires mime type defined for overwriting files.
 - 02/10/2020 - Cstadther - Fix import of skill themes.
 - 30/09/2020 - Cstadther - Fix for issue #363, where removing a specialization talent modifier did not actually remove the modifier, any subsequent modifier updates were additive.

--- a/modules/actors/actor-ffg.js
+++ b/modules/actors/actor-ffg.js
@@ -61,7 +61,7 @@ export class ActorFFG extends Actor {
         return { type: item, label: game.i18n.localize(`SWFFG.Skills${item}`) === `SWFFG.Skills${item}` ? item : game.i18n.localize(`SWFFG.Skills${item}`) };
       });
     }
-
+    this._prepareSharedData.bind(this);
     this._prepareSharedData(actorData);
     if (actorData.type === "minion") this._prepareMinionData(actorData);
     if (actorData.type === "character") this._prepareCharacterData(actorData);
@@ -96,6 +96,7 @@ export class ActorFFG extends Actor {
     }
 
     if (actorData.type === "minion" || actorData.type === "character") {
+      this._applyModifiers.bind(this);
       this._applyModifiers(actorData);
       if (game.settings.get("starwarsffg", "enableSoakCalc")) {
         this._calculateDerivedValues(actorData);
@@ -362,6 +363,7 @@ export class ActorFFG extends Actor {
    * @param  {string} modifierType
    */
   _setModifiers(actorData, properties, name, modifierType) {
+    const actor = this;
     const data = actorData.data;
     const attributes = Object.keys(data.attributes)
       .filter((key) =>
@@ -398,8 +400,16 @@ export class ActorFFG extends Actor {
           value = data[name][k].rank;
         } else if (key === "Shields") {
           value = [data[name][k].fore, data[name][k].port, data[name][k].starboard, data[name][k].aft];
+        } else if (key === "Soak") {
+          try {
+            if ((actor?._sheetClass?.name === "AdversarySheetFFG" && actorData.data.flags?.config?.enableAutoSoakCalculation) || game.settings.get("starwarsffg", "enableSoakCalc")) {
+              value = 0;
+            }
+          } catch (err) {
+            // swallow this exception as it only occurs during initialization of system.
+          }
         } else {
-          if (data[name][k]?.max) {
+          if (data[name][k]?.max && name !== "characteristics") {
             value = data[name][k].max;
           } else {
             value = data[name][k].value;
@@ -457,6 +467,8 @@ export class ActorFFG extends Actor {
       actorData.modifiers = {};
     }
 
+    this._setModifiers.bind(this);
+
     /* Characteristics */
     this._setModifiers(actorData, CONFIG.FFG.characteristics, "characteristics", "Characteristic");
     Object.keys(CONFIG.FFG.characteristics).forEach((key) => {
@@ -478,12 +490,12 @@ export class ActorFFG extends Actor {
       }
       if (key === "Wounds") {
         if (data.attributes.Wounds.value === 0) {
-          total = data.attributes.Brawn.value + ModifierHelpers.getBaseValue(actorData.items, "Brawn", "Characteristic");
+          total = data.attributes.Brawn.value; // + ModifierHelpers.getBaseValue(actorData.items, "Brawn", "Characteristic");
         }
       }
       if (key === "Strain") {
         if (data.attributes.Strain.value === 0) {
-          total = data.attributes.Willpower.value + ModifierHelpers.getBaseValue(actorData.items, "Willpower", "Characteristic");
+          total = data.attributes.Willpower.value; // + ModifierHelpers.getBaseValue(actorData.items, "Willpower", "Characteristic");
         }
       }
       if (key === "Encumbrance") {

--- a/modules/actors/adversary-sheet-ffg.js
+++ b/modules/actors/adversary-sheet-ffg.js
@@ -52,7 +52,7 @@ export class AdversarySheetFFG extends ActorSheet {
     }
     data.FFG = CONFIG.FFG;
     data.settings = {
-      enableSoakCalculation: game.settings.get("starwarsffg", "enableSoakCalc"),
+      enableSoakCalculation: this.actor.data.flags.enableAutoSoakCalculation || game.settings.get("starwarsffg", "enableSoakCalc"),
     };
 
     switch (this.actor.data.type) {

--- a/modules/helpers/actor-helpers.js
+++ b/modules/helpers/actor-helpers.js
@@ -33,8 +33,7 @@ export default class ActorHelpers {
             statValue = 0;
             isFormValueVisible = false;
           }
-        }
-        if (key === "Encumbrance") {
+        } else if (key === "Encumbrance") {
           if (formData.data.stats[k]?.value) {
             statValue = parseInt(formData.data.stats[k].value, 10);
             // the encumbrance value is autocalculated we need to account for 5 + Brawn
@@ -57,7 +56,12 @@ export default class ActorHelpers {
         }
 
         let x = statValue - (isFormValueVisible ? total : 0);
+
         let y = parseInt(formData.data.attributes[key].value, 10) + x;
+        if (key === "Soak" && (this.actor.data.flags.config.enableAutoSoakCalculation || game.settings.get("starwarsffg", "enableSoakCalc"))) {
+          y = 0;
+        }
+
         if (y > 0) {
           formData.data.attributes[key].value = y;
         } else {


### PR DESCRIPTION
Fixed issue with soak calculation if auto calculation is turned off then on
Removed adding willpower or brawn modifiers to Wound and Strain calculation, these should be calculated using only base characteristics, even though abilities could increase them, in which users should add ranks manually.