### PR TITLE
Added ability to add additional skills to initiative dialog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ See our current production goals and progress [here](https://github.com/StarWars
 
 # Changelog
 
+Release `CHANGELOG` can be found [here](https://github.com/StarWarsFoundryVTT/StarWarsFFG/releases)
+
+- 24/11/2020 - Cstadther - Enhancement 404 - Added ability to add additional skills to initiative dialog (Right-Click on skill and select `Toggle skill as initiative`).  Skills will be prefixed with a `*` on the skill list of the character sheet if they had been added as initiative skills (Vigilance and Cool will always be initiative skills).
 - 24/11/2020 - Cstadther - Enhancement 433 - Added rolling for Destiny Pool.  Right click on top/bottom destiny pool bar as GM to send a Roll chat message.  Players can click on roll button in chat to roll destiny.
 - 23/11/2020 - Cstadther - Enhancement - Moved Destiny Pool to its own FormApplication.  Added dragging bars to the top and bottom of the display.
 - 22/11/2020 - Cstadther - Enhancement - Added Boost/Setback/Failure/Threat to initiative dialog.  Updated styling.

--- a/lang/en.json
+++ b/lang/en.json
@@ -375,5 +375,6 @@
   "SWFFG.InitiativePoolAddsHint": "Add Success/Advantages to Roll.  Left click to increase dice, right click to decrease.",
   "SWFFG.RequestDestinyRoll": "Request Roll",
   "SWFFG.DestinyAlreadyRolled": "You have already rolled for the Destiny Pool!",
-  "SWFFG.DestinyPoolRoll": "Click here to roll for the Destiny Pool"
+  "SWFFG.DestinyPoolRoll": "Click here to roll for the Destiny Pool",
+  "SWFFG.SkillAddAsInitiative": "Toggle for use as initiative"
 }

--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -144,6 +144,13 @@ export class ActorSheetFFG extends ActorSheet {
         },
       },
       {
+        name: game.i18n.localize("SWFFG.SkillAddAsInitiative"),
+        icon: '<i class="fas fa-cog"></i>',
+        callback: (li) => {
+          this._onInitiativeSkill(li);
+        },
+      },
+      {
         name: game.i18n.localize("SWFFG.SkillRemoveContextItem"),
         icon: '<i class="fas fa-times"></i>',
         callback: (li) => {
@@ -666,6 +673,19 @@ export class ActorSheetFFG extends ActorSheet {
   _onRemoveSkill(a) {
     const ability = $(a).data("ability");
     this.object.update({ "data.skills": { ["-=" + ability]: null } });
+  }
+
+  _onInitiativeSkill(a) {
+    const skill = $(a).data("ability");
+    let updateData = {};
+
+    let useSkillForInitiative = false;
+    if (!this.object.data.data.skills[skill]?.useForInitiative) {
+      useSkillForInitiative = true;
+    }
+
+    setProperty(updateData, `data.skills.${skill}.useForInitiative`, useSkillForInitiative);
+    this.object.update(updateData);
   }
 
   /**

--- a/modules/combat-ffg.js
+++ b/modules/combat-ffg.js
@@ -44,9 +44,11 @@ export class CombatFFG extends Combat {
       const id = randomID();
 
       let whosInitiative = initiative.combatant.name;
+      let dicePools = [];
       let vigilanceDicePool = new DicePoolFFG({});
       let coolDicePool = new DicePoolFFG({});
       let addDicePool = new DicePoolFFG({});
+
       const defaultInitiativeFormula = formula || initiative._getInitiativeFormula();
       if (Array.isArray(ids) && ids.length > 1) {
         whosInitiative = "Multiple Combatants";
@@ -58,6 +60,28 @@ export class CombatFFG extends Combat {
 
         vigilanceDicePool = _buildInitiativePool(data, "Vigilance");
         coolDicePool = _buildInitiativePool(data, "Cool");
+
+        const initSkills = Object.keys(data.skills).filter((skill) => data.skills[skill].useForInitiative);
+
+        initSkills.forEach((skill) => {
+          if (dicePools.find((p) => p.name === skill)) return;
+
+          const skillPool = _buildInitiativePool(data, skill);
+          skillPool.label = data.skills[skill].label;
+          skillPool.name = skill;
+          dicePools.push(skillPool);
+        });
+      }
+
+      if (dicePools.findIndex((p) => p.name === "Vigilance") < 0) {
+        vigilanceDicePool.label = "SWFFG.SkillsNameVigilance";
+        vigilanceDicePool.name = "Vigilance";
+        dicePools.push(vigilanceDicePool);
+      }
+      if (dicePools.findIndex((p) => p.name === "Cool") < 0) {
+        coolDicePool.label = "SWFFG.SkillsNameCool";
+        coolDicePool.name = "Cool";
+        dicePools.push(coolDicePool);
       }
 
       const title = game.i18n.localize("SWFFG.InitiativeRoll") + ` ${whosInitiative}...`;
@@ -69,8 +93,7 @@ export class CombatFFG extends Combat {
           failure: PopoutEditor.renderDiceImages("[FA]"),
           threat: PopoutEditor.renderDiceImages("[TH]"),
         },
-        vigilanceDicePool,
-        coolDicePool,
+        dicePools,
         addDicePool,
         defaultInitiativeFormula,
       });
@@ -130,7 +153,7 @@ export class CombatFFG extends Combat {
                         token: c.token._id,
                         alias: c.token.name,
                       },
-                      flavor: `${c.token.name} ${game.i18n.localize("SWFFG.InitiativeRoll")} (${game.i18n.localize(`SWFFG.SkillsName${baseFormulaType}`)})`,
+                      flavor: `${c.token.name} ${game.i18n.localize("SWFFG.InitiativeRoll")} (${game.i18n.localize(`SWFFG.SkillsName${baseFormulaType.replace(/[: ]/g, "")}`)})`,
                       flags: { "core.initiativeRoll": true },
                     },
                     messageOptions

--- a/templates/dialogs/ffg-initiative.html
+++ b/templates/dialogs/ffg-initiative.html
@@ -1,10 +1,14 @@
 <div id="{{id}}" class="dialog-content initiative-dialog dice-pool-dialog">
   <div style="text-align: center;"><span>{{localize "SWFFG.InitiativePoolSelectorHint"}}</span></div>
   <div class="pool-selector">
-    <input type="radio" id="vigilance" name="skill" value="Vigilance" {{#if (eq defaultInitiativeFormula "Vigilance") }}checked{{/if}}>
+    {{#each dicePools as |p key|}} <input type="radio" id="{{key}}" name="skill" value="{{p.name}}" {{#if (eq ../defaultInitiativeFormula p.name) }}checked{{/if}}>
+    <label for="{{key}}">{{localize p.label}}</label>
+    {{/each}}
+
+    <!-- <input type="radio" id="vigilance" name="skill" value="Vigilance" {{#if (eq defaultInitiativeFormula "Vigilance") }}checked{{/if}}>
     <label for="vigilance">{{localize "SWFFG.SkillsNameVigilance"}}</label>
     <input type="radio" id="cool" name="skill" value="Cool" {{#if (eq defaultInitiativeFormula "Cool") }}checked{{/if}}>
-    <label for="cool">{{localize "SWFFG.SkillsNameCool"}}</label>
+    <label for="cool">{{localize "SWFFG.SkillsNameCool"}}</label> -->
   </div>
   <div id="Vigilancepool" class="hidden-content">
     {{#each vigilanceDicePool as |attr key|}}

--- a/templates/parts/actor/ffg-skills.html
+++ b/templates/parts/actor/ffg-skills.html
@@ -16,7 +16,7 @@
         {{#each ../data.skills as |skill id|}} {{#if (eq skill.type skilltype.type) }}
         <div data-ability="{{id}}" data-skilltype="{{skill.type}}" data-characteristic="{{skill.characteristic}}" class="pure-g skill" draggable="true">
           <div class="pure-u-12-24">
-            {{skill.label}} {{#with (lookup ../../this.FFG.characteristics [characteristic])~}} (
+            {{#if skill.useForInitiative}}*{{/if}} {{skill.label}} {{#with (lookup ../../this.FFG.characteristics [characteristic])~}} (
             <div class="skill-characteristic" data-characteristic="{{skill.characteristic}}">{{localize abrev}}</div>
             ) {{/with}}
           </div>


### PR DESCRIPTION
(Right-Click on skill and select `Toggle skill as initiative`).
Skills will be prefixed with a `*` on the skill list of the character sheet if they had been added as initiative skills
(Vigilance and Cool will always be initiative skills).

Fixes #404 