### PR TITLE
Fixed OggDude export with non-english characteristic names (now uses …

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See our current production goals and progress [here](https://github.com/StarWars
 
 Release `CHANGELOG` can be found [here](https://github.com/StarWarsFoundryVTT/StarWarsFFG/releases)
 
+- 28/12/2020 - Cstadther - Fix 569 - Fixed OggDude export with non-english characteristic names (now uses characteristic keys).  Added compendium migrations, as new version (1.3) will change importid property from importid to ffgimportid to resolve issue with Core migration overwriting property.
 - 28/12/2020 - Cstadther - Fix 553 - Fixed specialization link search for world compendiums that have been converted module compendiums.
 - 28/12/2020 - Cstadther - Enhancement 570 - Added "Send to All" option for roll dialog.
 - 22/12/2020 - Cstadther - Added Functional Testing.

--- a/modules/importer/import-helpers.js
+++ b/modules/importer/import-helpers.js
@@ -249,26 +249,7 @@ export default class ImportHelpers {
 
     if (["BR", "AG", "INT", "CUN", "WIL", "PR"].includes(mod.Key)) {
       modtype = "Characteristic";
-      switch (mod.Key) {
-        case "BR":
-          type = "Brawn";
-          break;
-        case "AG":
-          type = "Agility";
-          break;
-        case "INT":
-          type = "Intellect";
-          break;
-        case "CUN":
-          type = "Cunning";
-          break;
-        case "WIL":
-          type = "Willpower";
-          break;
-        case "PR":
-          type = "Presence";
-          break;
-      }
+      type = ImportHelpers.convertOGCharacteristic(mod.Key);
     }
 
     if (Object.keys(CONFIG.temporary.skills).includes(mod.Key)) {
@@ -422,6 +403,8 @@ export default class ImportHelpers {
       await callback(array[index], index, array);
     }
   };
+
+  static characteristicKeyToName(key) {}
 
   static async characterImport(data) {
     try {
@@ -674,17 +657,19 @@ export default class ImportHelpers {
       };
 
       characterData.Character.Characteristics.CharCharacteristic.forEach((char) => {
-        if (!character.data.attributes?.[char.name]) {
-          character.data.attributes[char.Name] = {
-            key: char.name,
-            mod: char.name,
+        const name = ImportHelpers.convertOGCharacteristic(char.Key);
+
+        if (!character.data.attributes?.[name]) {
+          character.data.attributes[name] = {
+            key: name,
+            mod: name,
             modtype: "Characteristic",
             value: 0,
           };
         }
         if (char.Rank?.PurchasedRanks) {
-          character.data.characteristics[char.Name].value = parseInt(char.Rank.PurchasedRanks, 10);
-          character.data.attributes[char.Name].value = parseInt(char.Rank.PurchasedRanks, 10);
+          character.data.characteristics[name].value = parseInt(char.Rank.PurchasedRanks, 10);
+          character.data.attributes[name].value = parseInt(char.Rank.PurchasedRanks, 10);
         }
       });
 
@@ -742,7 +727,9 @@ export default class ImportHelpers {
       updateDialog(10);
 
       try {
-        const species = JSON.parse(JSON.stringify(await this.findCompendiumEntityByImportId("Item", characterData.Character.Species.SpeciesKey)));
+        const x = await this.findCompendiumEntityByImportId("Item", characterData.Character.Species.SpeciesKey);
+
+        const species = JSON.parse(JSON.stringify(x));
         if (species) {
           for (let i = 0; i < speciesSkills.length; i += 1) {
             // first determine if the modifier exists, oggdudes doesn't differentiate between chosen skills (ie human) vs static skill (ie Nautolan)


### PR DESCRIPTION
…characteristic keys).

Added compendium migrations, as new version (1.3) will change importid property from importid to ffgimportid to resolve issue with Core migration overwriting property.

Fixes #569 