### PR TITLE
Fix result on the Ability die when rolling a "6" in Dice So Nice

### DIFF
--- a/modules/swffg-main.js
+++ b/modules/swffg-main.js
@@ -805,7 +805,7 @@ Hooks.once("diceSoNiceReady", (dice3d) => {
     dice3d.addDicePreset(
       {
         type: "da",
-        labels: ["", "s", "s", "s\ns", "a", "s", "s\na", "a\na"],
+        labels: ["", "s", "s", "s\ns", "a", "a", "s\na", "a\na"],
         font: "SWRPG-Symbol-Regular",
         colorset: "green",
         system: "swffg",
@@ -885,7 +885,7 @@ Hooks.once("diceSoNiceReady", (dice3d) => {
     dice3d.addDicePreset(
       {
         type: "da",
-        labels: ["", "s", "s", "s\ns", "a", "s", "s\na", "a\na"],
+        labels: ["", "s", "s", "s\ns", "a", "a", "s\na", "a\na"],
         font: "Genesys",
         colorset: "green",
         system: "genesys",


### PR DESCRIPTION
When rolling a nat6, the Dice So Nice Ability die was showing the wrong icon