### PR TITLE
downgrading difficulty or ability doesn't remove dice

### DIFF
--- a/modules/dice/pool.js
+++ b/modules/dice/pool.js
@@ -93,8 +93,6 @@ export class DicePoolFFG {
         if (this.proficiency > 0) {
           this.proficiency--;
           this.ability++;
-        } else if (this.ability > 0) {
-          this.ability--;
         }
       } else {
         if (this.ability > 0) {
@@ -126,9 +124,7 @@ export class DicePoolFFG {
         if (this.challenge > 0) {
           this.challenge--;
           this.difficulty++;
-        } else if (this.difficulty > 0) {
-          this.difficulty--;
-        }
+        } 
       } else {
         if (this.difficulty > 0) {
           this.difficulty--;


### PR DESCRIPTION
DOWNGRADING MORE DICE THAN AVAILABLE
There may be situations where a player needs to downgrade Proficiency dice into Ability dice or Challenge dice into Difficulty dice. If all the potential dice are already in their downgraded form, any further downgrades are ignored