### PR TITLE
Fix 648 - Fixed issue where qualities were reset on drag/drop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See our current production goals and progress [here](https://github.com/StarWars
 
 Release `CHANGELOG` can be found [here](https://github.com/StarWarsFoundryVTT/StarWarsFFG/releases)
 
+- 17/01/2021 - Cstadther - Fix 648 - Fixed issue where qualities were reset on drag/drop.
 - 16/01/2021 - Cstadther - Fix 636 - Fixed issues where Social Skill category is not longer being displays, also affected Labels on some of the skills.
 - 16/01/2021 - Cstadther - Added migration for alternate skill lists.
 - 16/01/2021 - Cstadther - Enhancement 633 - Added quality rendering to `Send To Chat` template.

--- a/template.json
+++ b/template.json
@@ -565,13 +565,16 @@
       },
       "itemattachments": {
         "itemattachment":[]
+      },
+      "qualities" : {
+        "itemmodifier": []
       }
     },
     "gear": {
       "templates": ["core", "basic"]
     },
     "weapon": {
-      "templates": ["core", "basic", "hardpoints", "equippable", "itemattachments"],
+      "templates": ["core", "basic", "hardpoints", "equippable", "itemattachments", "qualities"],
       "skill": {
         "value": "Ranged: Light",
         "type": "String",


### PR DESCRIPTION
The issue was that when dragging a a weapon from a compendium, it only copies data defined in the template.json, and qualities were not defined there for weapons.

Fixes #648 

NOTE:  This will require a restart of the server running the dev branch!