### PR TITLE
Set Adversary Group Skill Flag on Import

### DIFF
--- a/modules/importer/swa-importer.js
+++ b/modules/importer/swa-importer.js
@@ -422,10 +422,13 @@ export default class SWAImporter extends FormApplication {
                 }
 
                 if (item.skills) {
-                  Object.keys(item.skills).forEach((skill) => {
+                  let isMinion = Array.isArray(item.skills)
+                  let adversarySkills = isMinion ? item.skills : Object.keys(item.skills);
+                  adversarySkills.forEach((skill) => {
                     const ffgSkill = Object.keys(skills).find((s) => skill.toLowerCase() === s.toLowerCase());
 
                     if (ffgSkill) {
+                      adversary.data.skills[ffgSkill].groupskill = isMinion ? true : false;
                       adversary.data.skills[ffgSkill].rank = item.skills[skill];
                       if (CONFIG.temporary.swa.skills?.[skill]?.characteristic) {
                         adversary.data.skills[ffgSkill].characteristic = CONFIG.temporary.swa.skills[skill].characteristic;


### PR DESCRIPTION
Properly setting the Group Skill flag allows it so that ranks update
correctly as you update the quantity on Minion Actors. Only sets
groupskill to true on minion type adversaries.