### PR TITLE
it was not taking into account the header so I was checking if the sk…

### DIFF
--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -1094,7 +1094,7 @@ export class ActorSheetFFG extends ActorSheet {
         .sort(sortFunction);
 
       // if the skill list is larger that the column row count then take into account the added header row.
-      if (skills.length > colRowCount) {
+      if (skills.length >= colRowCount) {
         if (skills.length - colRowCount > 2) {
           colRowCount = Math.ceil((totalRows + 1) / 2.0);
           rowsLeft = colRowCount;


### PR DESCRIPTION
…ill rows in a group were greater than the skill split, not greater than or equal to, as it adds the header after the calculation