### PR TITLE
Improve FFG dice pool dialog UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5519,7 +5519,7 @@
         "string-width": "^1.0.2",
         "which-module": "^1.0.0",
         "y18n": "^3.2.1",
-        "yargs-parser": ">=5.0.0-security.0"
+        "yargs-parser": "5.0.0-security.0"
       }
     },
     "yargs-parser": {
@@ -5530,6 +5530,14 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
       }
     }
   }

--- a/scss/components/_dicepool.scss
+++ b/scss/components/_dicepool.scss
@@ -1,7 +1,10 @@
 .dice-pool-dialog {
   .dice-pool {
+    margin-top: 10px;
     min-height: 54px;
+    text-align: center;
   }
+  
   .pool-value {
     border: 1px solid black;
     background-color: #ddd;
@@ -13,19 +16,53 @@
       width:100%;
     }
   }
+
+  .pool-text {
+    text-align: left;
+
+    label {
+      margin-left: 1.2em;
+    }
+  }
+
   .upgrade-buttons {
     display: flex;
-    margin: 10px;
     button {
       line-height: 20px;
       font-size: 12px;
+      text-align: left;
+    }   
+  }
+
+  .pool-dice-pool {
+    padding: 5px 1px;
+    width: calc(100% - 2px);
+  }
+
+  .pool-additional-container {
+    padding: 0 1px;
+    width: calc(100% - 2px);
+    min-width: 300px;
+
+    .pool-additional {
+      text-align: left;
+      input[type="button"] {
+        margin: 0 3px;
+      }
     }
   }
-  .pool-additional {
-    text-align: left;
-    input[type="button"] {
-      margin: 0 3px;
+
+  .pool-roll-options {
+    margin-top: 10px;
+
+    select, input {
+      margin-top: 1px;
+      margin-right: 1px;
     }
+  }
+
+  .roll-button {
+    margin-top: 15px;
   }
 
   table {
@@ -39,12 +76,12 @@
   }
 
   .minimize {
-    max-width: 20%;
+    max-width: 20%;    
   }
 
   .maximize {
     width: 100%;
-    max-width: 78%;
+    // max-width: 78%;
   }
 }
 

--- a/styles/mandar.css
+++ b/styles/mandar.css
@@ -1181,7 +1181,9 @@ img {
 }
 
 .starwarsffg .dice-pool-dialog .dice-pool {
+  margin-top: 10px;
   min-height: 54px;
+  text-align: center;
 }
 
 .starwarsffg .dice-pool-dialog .pool-value {
@@ -1197,22 +1199,54 @@ img {
   width: 100%;
 }
 
+.starwarsffg .dice-pool-dialog .pool-text {
+  text-align: left;
+}
+
+.starwarsffg .dice-pool-dialog .pool-text label {
+  margin-left: 1.2em;
+}
+
 .starwarsffg .dice-pool-dialog .upgrade-buttons {
   display: flex;
-  margin: 10px;
 }
 
 .starwarsffg .dice-pool-dialog .upgrade-buttons button {
   line-height: 20px;
   font-size: 12px;
+  text-align: left;
+}
+
+.starwarsffg .dice-pool-dialog .pool-dice-pool {
+  padding: 5px 1px;
+  width: calc(100% - 2px);
+}
+
+.starwarsffg .dice-pool-dialog .pool-additional-container {
+  padding: 0 1px;
+  width: calc(100% - 2px);
+  min-width: 300px;
 }
 
 .starwarsffg .dice-pool-dialog .pool-additional {
   text-align: left;
 }
 
-.starwarsffg .dice-pool-dialog .pool-additional input[type="button"] {
+.starwarsffg .dice-pool-dialog .pool-additional-container .pool-additional input[type="button"] {
   margin: 0 3px;
+}
+
+.starwarsffg .dice-pool-dialog .pool-roll-options {
+  margin-top: 10px;
+}
+
+.starwarsffg .dice-pool-dialog .pool-roll-options select, .starwarsffg .dice-pool-dialog .pool-roll-options input {
+  margin-top: 1px;
+  margin-right: 1px;
+}
+
+.starwarsffg .dice-pool-dialog .roll-button {
+  margin-top: 15px;
 }
 
 .starwarsffg .dice-pool-dialog table {
@@ -1231,7 +1265,6 @@ img {
 
 .starwarsffg .dice-pool-dialog .maximize {
   width: 100%;
-  max-width: 78%;
 }
 
 .starwarsffg .ffgDiceArray {

--- a/styles/starwarsffg.css
+++ b/styles/starwarsffg.css
@@ -1238,7 +1238,9 @@ img {
 }
 
 .starwarsffg .dice-pool-dialog .dice-pool {
+  margin-top: 10px;
   min-height: 54px;
+  text-align: center;
 }
 
 .starwarsffg .dice-pool-dialog .pool-value {
@@ -1254,22 +1256,54 @@ img {
   width: 100%;
 }
 
+.starwarsffg .dice-pool-dialog .pool-text {
+  text-align: left;
+}
+
+.starwarsffg .dice-pool-dialog .pool-text label {
+  margin-left: 1.2em;
+}
+
 .starwarsffg .dice-pool-dialog .upgrade-buttons {
   display: flex;
-  margin: 10px;
 }
 
 .starwarsffg .dice-pool-dialog .upgrade-buttons button {
   line-height: 20px;
   font-size: 12px;
-}
-
-.starwarsffg .dice-pool-dialog .pool-additional {
   text-align: left;
 }
 
-.starwarsffg .dice-pool-dialog .pool-additional input[type="button"] {
+.starwarsffg .dice-pool-dialog .pool-dice-pool {
+  padding: 5px 1px;
+  width: calc(100% - 2px);
+}
+
+.starwarsffg .dice-pool-dialog .pool-additional-container {
+  padding: 0 1px;
+  width: calc(100% - 2px);
+  min-width: 300px;
+}
+
+.starwarsffg .dice-pool-dialog .pool-additional-container .pool-additional {
+  text-align: left;
+}
+
+.starwarsffg .dice-pool-dialog .pool-additional-container .pool-additional input[type="button"] {
   margin: 0 3px;
+}
+
+.starwarsffg .dice-pool-dialog .pool-roll-options {
+  margin-top: 10px;
+}
+
+.starwarsffg .dice-pool-dialog .pool-roll-options select, .starwarsffg .dice-pool-dialog .pool-roll-options input {
+  margin-top: 1px;
+  margin-right: 1px;
+}
+
+.starwarsffg .dice-pool-dialog .roll-button {
+  margin-top: 15px;
 }
 
 .starwarsffg .dice-pool-dialog table {
@@ -1288,7 +1322,6 @@ img {
 
 .starwarsffg .dice-pool-dialog .maximize {
   width: 100%;
-  max-width: 78%;
 }
 
 .starwarsffg .ffgDiceArray {

--- a/templates/dice/roll-options-ffg.html
+++ b/templates/dice/roll-options-ffg.html
@@ -3,61 +3,56 @@
     <div class="dice-pool"></div>
     <div class="upgrade-buttons">
       <button id="upgrade-ability">{{localize "SWFFG.UpgradeAbility"}}</button>
-      <button id="downgrade-ability">{{localize "SWFFG.DowngradeAbility"}}</button>
+      <button id="upgrade-difficulty">{{localize "SWFFG.UpgradeDifficulty"}}</button>
     </div>
     <div class="upgrade-buttons">
-      <button id="upgrade-difficulty">{{localize "SWFFG.UpgradeDifficulty"}}</button>
+      <button id="downgrade-ability">{{localize "SWFFG.DowngradeAbility"}}</button>
       <button id="downgrade-difficulty">{{localize "SWFFG.DowngradeDifficulty"}}</button>
     </div>
-    <div>
-      {{#if (or (eq isGM true) (eq canUserAddAudio true)) }}
-      <button id="add-sound" class="extend-button"><i class="fas fa-volume-up"></i></button>
-      <select class="sound-selection hide">
-        <option></option>
-        {{#each sounds}} <option value="{{this.path}}" {{#if this.selected}}selected{{/if}}>{{this.name}} {{/each}}
-      </select>
-      {{/if}}
-      <button id="add-flavor" class="extend-button"><i class="far fa-comment-dots"></i></button>
-      <input type="text" class="flavor-text hide" placeholder="Flavor Text" value="{{flavor}}" />
-      {{#if isGM}}
-      <button id="send-to-player" class="extend-button"><i class="fas fa-share"></i></button>
-      <select class="user-selection hide">
-        <option></option>
-        {{#each users}}
-        <option value="{{this.id}}">{{this.name}}</option>
-        {{/each}}
-      </select>
-      {{/if}}
+    <div style="margin: 10px 1px 5px 1px;">
+      <span><em>{{localize "SWFFG.DicePoolAddsHint"}}</em></span>
     </div>
-    <div style="text-align: center;"><span>{{localize "SWFFG.DicePoolAddsHint"}}</span></div>
     <table class="pool-additional-container">
       <tr>
-        <td class="pool-additional">{{{ffgDiceSymbols "[AD]"}}}<input type="button" name="advantage" min="0" />{{localize "SWFFG.Advantage"}}</td>
-        <td class="pool-additional">{{{ffgDiceSymbols "[SU]"}}}<input type="button" name="success" min="0" />{{localize "SWFFG.Success"}}</td>
-        {{#if enableForceDie}}
-        <td class="pool-additional">{{{ffgDiceSymbols "[LI]"}}}<input type="button" name="light" min="0" />{{localize labels.light}}</td>
-        {{else}}
-        <td class="pool-additional">{{{ffgDiceSymbols "[TR]"}}}<input type="button" name="triumph" min="0" />{{localize "SWFFG.Triumph"}}</td>
-        {{/if}}
+        <td class="pool-additional">{{{ffgDiceSymbols "[SU]"}}}</td>
+        <td class="pool-additional"><input type="button" name="success" min="0" /></td>
+        <td class="pool-additional"><label for="success">{{localize "SWFFG.Success"}}</label></td>
+
+        <td class="pool-additional">{{{ffgDiceSymbols "[FA]"}}}</td>
+        <td class="pool-additional"><input type="button" name="failure" min="0" /></td>
+        <td class="pool-additional"><label for="failure">{{localize "SWFFG.Failure"}}</label></td>
       </tr>
       <tr>
-        <td class="pool-additional">{{{ffgDiceSymbols "[TH]"}}}<input type="button" name="threat" min="0" />{{localize "SWFFG.Threat"}}</td>
-        <td class="pool-additional">{{{ffgDiceSymbols "[FA]"}}}<input type="button" name="failure" min="0" />{{localize "SWFFG.Failure"}}</td>
-        {{#if enableForceDie}}
-        <td class="pool-additional">{{{ffgDiceSymbols "[DA]"}}}<input type="button" name="dark" min="0" />{{localize labels.dark}}</td>
-        {{else}}
-        <td class="pool-additional">{{{ffgDiceSymbols "[DE]"}}}<input type="button" name="despair" min="0" />{{localize "SWFFG.Despair"}}</td>
-        {{/if}}
+        <td class="pool-additional">{{{ffgDiceSymbols "[AD]"}}}</td>
+        <td class="pool-additional"><input type="button" name="advantage" min="0" /></td>
+        <td class="pool-additional"><label for="advantage">{{localize "SWFFG.Advantage"}}</label></td>
+
+        <td class="pool-additional">{{{ffgDiceSymbols "[TH]"}}}</td>
+        <td class="pool-additional"><input type="button" name="threat" min="0" /></td>
+        <td class="pool-additional"><label for="threat">{{localize "SWFFG.Threat"}}</label></td>
+      </tr>
+      <tr>
+        <td class="pool-additional">{{{ffgDiceSymbols "[TR]"}}}</td>
+        <td class="pool-additional"><input type="button" name="triumph" min="0" /></td>
+        <td class="pool-additional"><label for="triumph">{{localize "SWFFG.Triumph"}}</label></td>
+
+        <td class="pool-additional">{{{ffgDiceSymbols "[DE]"}}}</td>
+        <td class="pool-additional"><input type="button" name="despair" min="0" /></td>
+        <td class="pool-additional"><label for="despair">{{localize "SWFFG.Despair"}}</label></td>
       </tr>
       {{#if enableForceDie}}
       <tr>
-        <td class="pool-additional">{{{ffgDiceSymbols "[TR]"}}}<input type="button" name="triumph" min="0" />{{localize "SWFFG.Triumph"}}</td>
-        <td></td>
-        <td class="pool-additional">{{{ffgDiceSymbols "[DE]"}}}<input type="button" name="despair" min="0" />{{localize "SWFFG.Despair"}}</td>
+        <td class="pool-additional">{{{ffgDiceSymbols "[LI]"}}}</td>
+        <td class="pool-additional"><input type="button" name="light" min="0" /></td>
+        <td class="pool-additional"><label for="light">{{localize labels.light}}</label></td>
+
+        <td class="pool-additional">{{{ffgDiceSymbols "[DA]"}}}</td>
+        <td class="pool-additional"><input type="button" name="dark" min="0" /></td>
+        <td class="pool-additional"><label for="dark">{{localize labels.dark}}</label></td>
       </tr>
       {{/if}}
     </table>
-    <table>
+    <table class="pool-dice-pool">
       <tr class="pool-container flex-group-center">
         <td><img src="systems/starwarsffg/images/dice/starwars/yellow.png" width="30" height="30" /></td>
         <td>
@@ -65,42 +60,42 @@
             <input type="button" name="proficiency" min="0" />
           </div>
         </td>
-        <td>{{localize "SWFFG.DiceProficiency"}}</td>
+        <td class="pool-text"><label for="proficiency">{{localize "SWFFG.DiceProficiency"}}</label></td>
       </tr>
       <tr class="pool-container flex-group-center">
         <td><img src="systems/starwarsffg/images/dice/starwars/green.png" width="30" height="30" /></td>
         <td>
           <div class="pool-value"><input type="button" name="ability" min="0" /></div>
         </td>
-        <td>{{localize "SWFFG.DiceAbility"}}</td>
+        <td class="pool-text"><label for="ability">{{localize "SWFFG.DiceAbility"}}</label></td>
       </tr>
       <tr class="pool-container flex-group-center">
         <td><img src="systems/starwarsffg/images/dice/starwars/red.png" width="30" height="30" /></td>
         <td>
           <div class="pool-value"><input type="button" name="challenge" min="0" /></div>
         </td>
-        <td>{{localize "SWFFG.DiceChallenge"}}</td>
+        <td class="pool-text"><label for="challenge">{{localize "SWFFG.DiceChallenge"}}</label></td>
       </tr>
       <tr class="pool-container flex-group-center">
         <td><img src="systems/starwarsffg/images/dice/starwars/purple.png" width="30" height="30" /></td>
         <td>
           <div class="pool-value"><input type="button" name="difficulty" min="0" /></div>
         </td>
-        <td>{{localize "SWFFG.DiceDifficulty"}}</td>
+        <td class="pool-text"><label for="difficulty">{{localize "SWFFG.DiceDifficulty"}}</label></td>
       </tr>
       <tr class="pool-container flex-group-center">
         <td><img src="systems/starwarsffg/images/dice/starwars/blue.png" width="30" height="30" /></td>
         <td>
           <div class="pool-value"><input type="button" name="boost" min="0" /></div>
         </td>
-        <td>{{localize "SWFFG.DiceBoost"}}</td>
+        <td class="pool-text"><label for="boost">{{localize "SWFFG.DiceBoost"}}</label></td>
       </tr>
       <tr class="pool-container flex-group-center">
         <td><img src="systems/starwarsffg/images/dice/starwars/black.png" width="30" height="30" /></td>
         <td>
           <div class="pool-value"><input type="button" name="setback" min="0" /></div>
         </td>
-        <td>{{localize "SWFFG.DiceSetback"}}</td>
+        <td class="pool-text"><label for="setback">{{localize "SWFFG.DiceSetback"}}</label></td>
       </tr>
       {{#if enableForceDie}}
       <tr class="pool-container flex-group-center">
@@ -108,10 +103,38 @@
         <td>
           <div class="pool-value"><input type="button" name="force" min="0" /></div>
         </td>
-        <td>{{localize "SWFFG.DiceForce"}}</td>
+        <td class="pool-text"><label for="force">{{localize "SWFFG.DiceForce"}}</label></td>
       </tr>
       {{/if}}
     </table>
+    <div class="pool-roll-options">
+      {{#if (or (eq isGM true) (eq canUserAddAudio true)) }}
+      <div class="flexrow">
+        <button id="add-sound" class="extend-button"><i class="fas fa-volume-up"></i></button>
+        <select class="sound-selection hide">
+          <option></option>
+          {{#each sounds}} <option value="{{this.path}}" {{#if this.selected}}selected{{/if}}>{{this.name}} {{/each}}
+        </select>
+      </div>
+      {{/if}}
+      <div class="flexrow">
+        <button id="add-flavor" class="extend-button"><i class="far fa-comment-dots"></i></button>
+        <input type="text" class="flavor-text hide" placeholder="Flavor Text" value="{{flavor}}" />
+      </div>
+      {{#if isGM}}
+      <div class="flexrow">
+        <button id="send-to-player" class="extend-button"><i class="fas fa-share"></i></button>
+        <select class="user-selection hide">
+          <option></option>
+          {{#each users}}
+          <option value="{{this.id}}">{{this.name}}</option>
+          {{/each}}
+        </select>
+      </div>
+      {{/if}}
+    </div>
+    <div class="roll-button flexrow">
+      <button class="btn">{{localize "SWFFG.SkillsRoll"}}</button>
+    </div>
   </div>
-  <button class="btn">{{localize "SWFFG.SkillsRoll"}}</button>
 </form>


### PR DESCRIPTION
The motivation behind this commit is to improve the readability and reduce the perceived visual complexity of the FFG dice pool dialogue.

Centred the dice to give them more room and balance.
Aligned buttons so that they align with the surrounding elements and blocks.
Added spacing between the different sections.
Reordered buttons to upgrade or downgrade abilities and difficulty so that the ability buttons are on the left and the difficulty buttons are on the right. This matches how the dice are displayed and how the section with the added results is ordered.
The text on these buttons is now left-aligned to improve scanning and readability.
The text explaining how to increase or decrease dice is now emphasised and left-aligned.
Left-aligned the text for the various dice for better scanning and readability.
Reordered the results section so that positive (ability) results are on the left and negative (difficulty) are on the right. Reduced this section to two main columns to reduce complexity and improve flow.
Moved audio/chat options to the bottom so that the dice options are grouped together.

![starwarsffg-default-diceroll-improvements](https://user-images.githubusercontent.com/2065748/111887196-adaf8c80-89d3-11eb-9139-a264de4af18a.jpg)
