### PR TITLE
Fix #858 - correct typo in vehicle.js log message

### DIFF
--- a/modules/importer/oggdude/importers/vehicles.js
+++ b/modules/importer/oggdude/importers/vehicles.js
@@ -114,7 +114,7 @@ export default class Vehicles {
 
                   data.items.push(weaponData);
                 } else {
-                  CONFIG.logger.warn(`Unable to find weaon : ${weapon.Key}`);
+                  CONFIG.logger.warn(`Unable to find weapon : ${weapon.Key}`);
                 }
               });
             }


### PR DESCRIPTION
Fix #858 - Correct typo of word `weapon` in vehicle.js log message (was `weaon`).