### PR TITLE
Allow Unlinked Token Weapon Rolls

### DIFF
--- a/modules/helpers/dice-helpers.js
+++ b/modules/helpers/dice-helpers.js
@@ -57,12 +57,20 @@ export default class DiceHelpers {
     // Determine if this roll is triggered by an item.
     let item = {};
     if ($(row.parentElement).hasClass("item")) {
-      let itemID = row.parentElement.dataset["itemId"];
-      const item1 = actor.getOwnedItem(itemID);
-      item = Object.entries(data.items).filter((item) => item[1]._id === itemID);
-      item = item[0][1];
-      item.flags.uuid = item1.uuid;
-    }
+      //Check if token is linked to actor
+      if (obj.actor.token === null) {
+          let itemID = row.parentElement.dataset["itemId"];
+          const item1 = actor.getOwnedItem(itemID);
+          item = Object.entries(data.items).filter((item) => item[1]._id === itemID);
+          item = item[0][1];
+          item.flags.uuid = item1.uuid;
+      } else {
+          //Rolls this if unlinked
+          let itemID = row.parentElement.dataset["itemId"];
+          item = obj.actor.token.actor.items.filter((i) => i._id === itemID);
+          item = item[0].data;
+      }
+  }
     const status = this.getWeaponStatus(item);
 
     // TODO: Get weapon specific modifiers from itemmodifiers and itemattachments

--- a/modules/helpers/modifiers.js
+++ b/modules/helpers/modifiers.js
@@ -188,11 +188,16 @@ export default class ModifierHelpers {
     let checked = false;
     let sources = [];
 
+    let rank = item.data.rank;
+    if(rank === null) {
+      rank = 1;
+    }
+
     const filteredAttributes = Object.values(item.data.attributes).filter((a) => a.modtype === modtype && a.mod === key);
 
     filteredAttributes.forEach((attr) => {
-      sources.push({ modtype, key, name: item.name, value: attr.value, type: item.type });
-      total += parseInt(attr.value, 10);
+      sources.push({ modtype, key, name: item.name, value: attr.value * rank, type: item.type });
+      total += parseInt(attr.value * rank, 10);
     });
 
     const itemsTotal = ModifierHelpers.getCalculatedValueFromItems(items, key, modtype, includeSource);


### PR DESCRIPTION
Unlinked tokens could not roll weapons that were added on their token sheets but not original actor sheets.
#873 