### PR TITLE
Fix for encumbrance dropped to 0

### DIFF
--- a/modules/actors/actor-ffg.js
+++ b/modules/actors/actor-ffg.js
@@ -343,7 +343,7 @@ export class ActorFFG extends Actor {
             if (item.data?.quantity?.value) {
               count = item.data.quantity.value;
             }
-            encum += ((item.data?.encumbrance?.adjusted) ? item.data?.encumbrance?.adjusted : item.data?.encumbrance?.value) * count;
+            encum += ((item.data?.encumbrance?.adjusted >= 0) ? item.data?.encumbrance?.adjusted : item.data?.encumbrance?.value) * count;
           }
         }
       } catch (err) {


### PR DESCRIPTION
When an item's adjusted value was dropped to 0, it would default to value instead. #920 