### PR TITLE
Fix encumbrance calculation

### DIFF
--- a/modules/actors/actor-ffg.js
+++ b/modules/actors/actor-ffg.js
@@ -338,12 +338,18 @@ export class ActorFFG extends Actor {
           if (item.type === "armour" && item?.data?.equippable?.equipped) {
             const equippedEncumbrance = +item.data.encumbrance.adjusted - 3;
             encum += equippedEncumbrance > 0 ? equippedEncumbrance : 0;
+          } else if (item.type === "armour" || item.type === "weapon" || item.type === "shipweapon") {
+            let count = 1;
+            if (item.data?.quantity?.value) {
+              count = item.data.quantity.value;
+            }
+            encum += ((item.data?.encumbrance?.adjusted !== undefined) ? item.data?.encumbrance?.adjusted : item.data?.encumbrance?.value) * count;
           } else {
             let count = 1;
             if (item.data?.quantity?.value) {
               count = item.data.quantity.value;
             }
-            encum += (item.data?.encumbrance?.adjusted !== undefined ? item.data?.encumbrance?.adjusted : item.data?.encumbrance?.value) * count;
+            encum += item.data?.encumbrance?.value * count;
           }
         }
       } catch (err) {


### PR DESCRIPTION
Any items that aren't weapons, armor, or shipweapons were not getting their adjusted value set so the calculation was incorrect. #937 