### PR TITLE
Item Modifier Viewing Permissions

### DIFF
--- a/modules/helpers/embeddeditem-helpers.js
+++ b/modules/helpers/embeddeditem-helpers.js
@@ -144,7 +144,7 @@ export default class EmbeddedItemHelpers {
         name: item.name,
         content: item.data.description,
         permission: {
-          default: ENTITY_PERMISSIONS.OBSERVER,
+          default: CONST.ENTITY_PERMISSIONS.OBSERVER,
         },
       };
 


### PR DESCRIPTION
Clicking on an item modifier pill gave two errors. One is due to a missing id and the other is not valid permissions. This one fixes the permissions. One of two fixes for #943 