### PR TITLE
Speaker Data

### DIFF
--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -56,6 +56,7 @@ export class ActorSheetFFG extends ActorSheet {
     data.data = actorData.data;
     data.rollData = this.actor.getRollData.bind(this.actor);
 
+    data.token = this.token?.data;
     data.items = this.actor.items.map((item) => item.data);
 
     if (options?.action === "update" && this.object.compendium) {

--- a/modules/dice/roll-builder.js
+++ b/modules/dice/roll-builder.js
@@ -166,7 +166,11 @@ export default class RollBuilderFFG extends FormApplication {
         const roll = new game.ffg.RollFFG(this.dicePool.renderDiceExpression(), this.roll.item, this.dicePool, this.roll.flavor);
         roll.toMessage({
           user: game.user.id,
-          speaker: { actor: game.actors.get(this.roll.data?.actor?._id) },
+          speaker: {
+            actor: game.actors.get(this.roll.data?.actor?._id),
+            alias: this.roll.data?.token?.name,
+            token: this.roll.data?.token?._id,
+          },
           flavor: `${game.i18n.localize("SWFFG.Rolling")} ${game.i18n.localize(this.roll.skillName)}...`,
         });
         if (this.roll?.sound) {


### PR DESCRIPTION
Added token Data to the getData function of the actor sheet for use in roll builder.
Added token alias and id to speaker information.

This makes it so the name displayed on the roll is the one set on the Token, not the Actors sheet, and allows modules access to the source token of a roll.