### PR TITLE
Careerskills not loading

### DIFF
--- a/modules/actors/actor-ffg.js
+++ b/modules/actors/actor-ffg.js
@@ -24,7 +24,7 @@ export class ActorFFG extends Actor {
 
       Object.keys(data.skills)
         .filter((skill) => {
-          return data.skills[skill].custom;
+          return data.skills[skill].custom || data.skills[skill].careerskill;
         })
         .forEach((skill) => {
           actorSkills[skill] = {


### PR DESCRIPTION
makes sure regular skills flagged as careerskills are also loaded into actor skills