### PR TITLE
add data-item-id in chat rolls

### DIFF
--- a/templates/chat/force-power-card.html
+++ b/templates/chat/force-power-card.html
@@ -1,4 +1,4 @@
-<div class="starwarsffg item-card force-power-card">
+<div class="starwarsffg item-card force-power-card" data-item-id="{{item._id}}">
   <h2>{{item.name}}</h2>
   <h3>{{itemDetails.name}}</h3>
   <div class="item-details">

--- a/templates/chat/item-card.html
+++ b/templates/chat/item-card.html
@@ -1,4 +1,4 @@
-<div class="starwarsffg item-card">
+<div class="starwarsffg item-card" data-item-id="{{item._id}}">
   {{#if (ne item.img "icons/svg/mystery-man.svg")}}
   <h3><img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" /></h3>
   {{/if}}

--- a/templates/chat/roll-forcepower-card.html
+++ b/templates/chat/roll-forcepower-card.html
@@ -1,4 +1,4 @@
-<div class="item-display">
+<div class="item-display" data-item-id="{{data._id}}">
   {{#if (ne data.img "icons/svg/mystery-man.svg")}}
   <img class="item-image" src="{{data.img}}" />
   {{/if}}

--- a/templates/chat/roll-weapon-card.html
+++ b/templates/chat/roll-weapon-card.html
@@ -1,4 +1,4 @@
-<div class="item-display">
+<div class="item-display" data-item-id="{{data._id}}">
   {{#if (ne data.img "icons/svg/mystery-man.svg")}}
   <img class="item-image" src="{{data.img}}" />
   {{/if}}


### PR DESCRIPTION
Add data-item-id attribute to outermost HTML element on chat rolls. It allows compatibility with modules that look for the item id in this attribute when an item is rolled (like Maestro). Addresses #970 