### PR TITLE
Fix deprecated option warning in TextEditor.enrichHTML usage.

### DIFF
--- a/modules/popout-editor.js
+++ b/modules/popout-editor.js
@@ -57,7 +57,7 @@ export default class PopoutEditor extends FormApplication {
 
     html = this.replaceRollTags(html, actorData);
     try {
-      html = TextEditor.enrichHTML(html, { secrets: true, entities: true });
+      html = TextEditor.enrichHTML(html, { secrets: true, documents: true });
     } catch (err) {
       // ignore the message below, it means that we already created an entity link (this could be part of an editor text)
       if (err.message !== "An Entity subclass must configure the EntityCollection it belongs to.") {


### PR DESCRIPTION
`entities` option  should now be `documents`