### PR TITLE
Fix numeric dice rolling in Foundry v9.x

### DIFF
--- a/modules/dice/diceterm.js
+++ b/modules/dice/diceterm.js
@@ -1,0 +1,26 @@
+export class DiceTermFFG extends DiceTerm {
+  constructor(termData) {
+    super(termData);
+  }
+
+  static fromMatch(match) {
+    let [number, denomination, modifiers, flavor] = match.slice(1);
+
+    // Get the denomination of DiceTerm
+    denomination = denomination.toLowerCase();
+    const cls = denomination in CONFIG.Dice.terms ? CONFIG.Dice.terms[denomination] : CONFIG.Dice.types[0];
+    if ( !foundry.utils.isSubclass(cls, DiceTerm) ) {
+      throw new Error(`DiceTerm denomination ${denomination} not registered to CONFIG.Dice.terms as a valid DiceTerm class`);
+    }
+
+    // Get the term arguments
+    number = Number.isNumeric(number) ? parseInt(number) : 1;
+    const faces = Number.isNumeric(denomination) ? parseInt(denomination) : null;
+
+    // Match modifiers
+    modifiers = Array.from((modifiers || "").matchAll(DiceTerm.MODIFIER_REGEXP)).map(m => m[0]);
+
+    // Construct a term of the appropriate denomination
+    return new cls({number, faces, modifiers, options: {flavor}});
+  }
+}

--- a/modules/dice/dietype/AbilityDie.js
+++ b/modules/dice/dietype/AbilityDie.js
@@ -1,4 +1,6 @@
-export class AbilityDie extends DiceTerm {
+import { DiceTermFFG } from '../diceterm.js';
+
+export class AbilityDie extends DiceTermFFG {
   constructor(termData) {
     super(termData);
     this.faces = 8;

--- a/modules/dice/dietype/BoostDie.js
+++ b/modules/dice/dietype/BoostDie.js
@@ -1,4 +1,6 @@
-export class BoostDie extends DiceTerm {
+import { DiceTermFFG } from '../diceterm.js';
+
+export class BoostDie extends DiceTermFFG {
   constructor(termData) {
     super(termData);
     this.faces = 6;

--- a/modules/dice/dietype/ChallengeDie.js
+++ b/modules/dice/dietype/ChallengeDie.js
@@ -1,4 +1,6 @@
-export class ChallengeDie extends DiceTerm {
+import { DiceTermFFG } from '../diceterm.js';
+
+export class ChallengeDie extends DiceTermFFG {
   constructor(termData) {
     super(termData);
     this.faces = 12;

--- a/modules/dice/dietype/DifficultyDie.js
+++ b/modules/dice/dietype/DifficultyDie.js
@@ -1,4 +1,6 @@
-export class DifficultyDie extends DiceTerm {
+import { DiceTermFFG } from '../diceterm.js';
+
+export class DifficultyDie extends DiceTermFFG {
   constructor(termData) {
     super(termData);
     this.faces = 8;

--- a/modules/dice/dietype/ForceDie.js
+++ b/modules/dice/dietype/ForceDie.js
@@ -1,4 +1,6 @@
-export class ForceDie extends DiceTerm {
+import { DiceTermFFG } from '../diceterm.js';
+
+export class ForceDie extends DiceTermFFG {
   constructor(termData) {
     super(termData);
     this.faces = 12;

--- a/modules/dice/dietype/ProficiencyDie.js
+++ b/modules/dice/dietype/ProficiencyDie.js
@@ -1,4 +1,6 @@
-export class ProficiencyDie extends DiceTerm {
+import { DiceTermFFG } from '../diceterm.js';
+
+export class ProficiencyDie extends DiceTermFFG {
   constructor(termData) {
     super(termData);
     this.faces = 12;

--- a/modules/dice/dietype/SetbackDie.js
+++ b/modules/dice/dietype/SetbackDie.js
@@ -1,4 +1,6 @@
-export class SetbackDie extends DiceTerm {
+import { DiceTermFFG } from '../diceterm.js';
+
+export class SetbackDie extends DiceTermFFG {
   constructor(termData) {
     super(termData);
     this.faces = 6;

--- a/modules/swffg-main.js
+++ b/modules/swffg-main.js
@@ -35,6 +35,7 @@ import { createFFGMacro } from "./helpers/macros.js";
 import EmbeddedItemHelpers from "./helpers/embeddeditem-helpers.js";
 import DataImporter from "./importer/data-importer.js";
 import PauseFFG from "./apps/pause-ffg.js";
+import { DiceTermFFG } from './dice/diceterm.js';
 
 /* -------------------------------------------- */
 /*  Foundry VTT Initialization                  */
@@ -68,6 +69,7 @@ Hooks.once("init", async function () {
   // Define custom Roll class
   CONFIG.Dice.rolls.push(CONFIG.Dice.rolls[0]);
   CONFIG.Dice.rolls[0] = RollFFG;
+  CONFIG.Dice.termTypes.DiceTerm = DiceTermFFG;
 
   // Define DiceTerms
   CONFIG.Dice.terms["a"] = AbilityDie;


### PR DESCRIPTION
As DiceTerm#fromMatch was refactored to default to CONFIG.Dice.terms.d for numeric denominators, we have to overwrite it ourselves and go back to the old behaviour.

A bit hacky. I'm sad about it. But it works.