### PR TITLE
Flag bugfixes

### DIFF
--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -36,11 +36,11 @@ export class ItemFFG extends ItemBaseFFG {
     const data = itemData.data;
 
     if (!itemData.flags.starwarsffg) {
-      this.update({
+      itemData.update({
         flags: {
           starwarsffg: {
             isCompendium: this.compendium,
-            ffgUuid: this.uuid || null,
+            ffgUuid: this.parent?.data ? this.uuid : null,
             ffgIsOwned: this.isEmbedded,
             loaded: false
           }

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "starwarsffg",
   "title": "Star Wars FFG",
   "description": "A system for playing Star Wars FFG games.",
-  "version": "1.61",
+  "version": "1.62",
   "minimumCoreVersion": "0.8.9",
   "compatibleCoreVersion": "9",
   "templateVersion": 1,


### PR DESCRIPTION
Need to wrap `this.uuid` usage in `this.parent.data` check for older worlds.

Migration of the compendium packs wasn't working as expected. This tries to fix it, but I'm not convinced.