### PR TITLE
fix(flags): correct flag error when creating actor

### DIFF
--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -1038,6 +1038,9 @@ export class ActorSheetFFG extends ActorSheet {
    */
   async _updateSpecialization(data) {
     CONFIG.logger.debug(`Running Actor initial load`);
+    if (this.actor.data.flags.starwarsffg === undefined) {
+        this.actor.data.flags.starwarsffg = {};
+    }
     this.actor.data.flags.starwarsffg.loaded = true;
 
     const specializations = this.actor.data.items.filter((item) => {


### PR DESCRIPTION
Fix the flag error when creating actors on v9.

The migration code should probably also be updated to make sure to pre-define all levels of data (since it looks like this one got missed), but I'm not familiar with that code.