### PR TITLE
fix(qualities): hack to fix item qualities in chat

### DIFF
--- a/modules/dice/roll.js
+++ b/modules/dice/roll.js
@@ -272,6 +272,14 @@ export class RollFFG extends Roll {
       addedResults: this.addedResults,
       publicRoll: !chatOptions.isPrivate,
     };
+    if (chatData.data.data.adjusteditemmodifier === undefined) {
+      // extended metadata is missing, lookup the actor ID so we can embed it for future lookups
+      let candidate_actors = game.actors.filter(actor => actor.items.filter(item => item.id === chatData.data._id).length > 0);
+      if (candidate_actors.length > 0) {
+        // fake the UUID flag so we can do the lookup within chat messages
+        chatData.data.flags.starwarsffg.ffgUuid = 'Actor.' + candidate_actors[0].id + '.Item.' + chatData.data._id;
+      }
+    }
 
     // Render the roll display template
     return renderTemplate(chatOptions.template, chatData);

--- a/templates/chat/roll-weapon-card.html
+++ b/templates/chat/roll-weapon-card.html
@@ -17,5 +17,15 @@
     </h5>
   </div>
   {{/if}}
+  {{#if data.data.itemmodifier}}
+  {{#iff data.data.adjusteditemmodifier '==' undefined }}
+  <div class="specials">
+    <h5>
+      {{#each data.data.itemmodifier as |item id|}}
+      <li class="item-pill" data-item-id="{{../data.flags.starwarsffg.ffgUuid}}" data-modifier-id="{{item.id}}" data-modifier-type="{{item.type}}">{{item.name}} {{#if (gt item.data.rank 0)}}{{item.data.rank}}{{else}}{{/if}}</li>
+      {{/each}}
+    </h5>
+  </div>
+  {{/iff}}{{/if}}
   {{#if data.data.special.value}}{{{ffgDiceSymbols data.data.special.value}}}{{/if}}
 </div>


### PR DESCRIPTION
Fixes #1007. Tested on the latest v9 and on `0.8.9`. Note that items with blank qualities included break (not sure if they did already), but it's trivial to fix - just remove the blank quality.