### PR TITLE
Add ability to use custom dice sets

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -289,7 +289,7 @@
   "SWFFG.SettingsSkillSorting": "Sort skills by localised name?",
   "SWFFG.SettingsSkillSortingHint": "By default skills will be sorted alphabetically by the original English names on the character sheets. Enable this setting if you would prefer sorting to use the localised skill names instead.",
   "SWFFG.SettingsDiceTheme": "Choose Dice Theme",
-  "SWFFG.SettingsDiceThemeHint": "Switch between Star Wars or Genesys style dice.",
+  "SWFFG.SettingsDiceThemeHint": "Switch between Star Wars or Genesys style dice, or upload your own set to systems/starwarsffg/images/dice/custom.",
   "SWFFG.SettingsVehicleRange": "Choose Vehicle Range System",
   "SWFFG.SettingsVehicleRangeHint": "Switch between Star Wars or Genesys vehicle range bands.",
   "SWFFG.TalentsForce": "Force Talent?",

--- a/modules/settings/settings-helpers.js
+++ b/modules/settings/settings-helpers.js
@@ -31,6 +31,7 @@ export default class SettingsHelpers {
       choices: {
         starwars: "starwars",
         genesys: "genesys",
+        custom: "custom",
       },
     });
 


### PR DESCRIPTION
So my group is playing a 40k themed Genesys campaign, and one of the players wanted to make 40k themed dice skins. This is just a quick change to allow the system to load dice skind placed in `systems/starwarsffg/images/dice/custom`.

I'm not sure if this is the best way to do it, though? If the user deletes and reinstalls the system the dice skin files would be deleted, and I'm not sure if they are also deleted during a normal update. I'm open to suggestions on how to do this better before it's merged!

I could for instance rewrite `ffg-dice.js` to use a completely custom path outside the system folder if such a path is set by the user for their custom assets?