### PR TITLE
Handle combatant being undefined

### DIFF
--- a/modules/combat-ffg.js
+++ b/modules/combat-ffg.js
@@ -43,7 +43,7 @@ export class CombatFFG extends Combat {
     let promise = new Promise(async function (resolve, reject) {
       const id = randomID();
 
-      let whosInitiative = initiative.combatant.name;
+      let whosInitiative = initiative.combatant?.name;
       let dicePools = [];
       let vigilanceDicePool = new DicePoolFFG({});
       let coolDicePool = new DicePoolFFG({});
@@ -105,7 +105,7 @@ export class CombatFFG extends Combat {
             label: game.i18n.localize("SWFFG.InitiativeRoll"),
             callback: async () => {
               const container = document.getElementById(id);
-              const currentId = initiative.combatant.id;
+              const currentId = initiative.combatant?.id;
 
               const baseFormulaType = container.querySelector('input[name="skill"]:checked').value;
 
@@ -175,8 +175,8 @@ export class CombatFFG extends Combat {
               // Update multiple combatants
               await initiative.updateEmbeddedDocuments("Combatant", updates);
 
-              // Ensure the turn order remains with the same combatant
-              if (updateTurn) {
+              // Ensure the turn order remains with the same combatant if there was one active
+              if (updateTurn && !!currentId) {
                 await initiative.update({ turn: initiative.turns.findIndex((t) => t.id === currentId) });
               }
 


### PR DESCRIPTION
In foundry v9, turn is allowed to be set to null in order to mark that
there is no active combatant. When this is the case, the combatant
getter for the current combatant will return undefined. By option
chaining the name and id properties, this removes an exception that
prevents the dialog from opening.

Additionally, when updating the turn after rolling initiative, prevent
trying to update the turn to -1 and raising an error.

Ref: BoltsJ/lancer-initiative#20, BoltsJ/lancer-initiative#25
