### PR TITLE
Adding in Skill Rank Cap for Minions

### DIFF
--- a/modules/actors/actor-ffg.js
+++ b/modules/actors/actor-ffg.js
@@ -110,6 +110,8 @@ export class ActorFFG extends Actor {
         // Check we don't go below 0.
         if (skill.rank < 0) {
           skill.rank = 0;
+        } else if (skill.rank > 5) {
+          skill.rank = 5;
         }
       } else if (!skill.groupskill) {
         skill.rank = data.attributes[key].value;


### PR DESCRIPTION
Setting a max of 5 for group skills.
Adding link: #1070 