### PR TITLE
Make parts of roll dialog collapsible

### DIFF
--- a/templates/dice/roll-options-ffg.html
+++ b/templates/dice/roll-options-ffg.html
@@ -1,4 +1,4 @@
-<form>
+<form style="overflow-y: scroll; scrollbar-width: thin;">
   <div class="dice-pool-dialog">
     <div class="dice-pool"></div>
     <div class="upgrade-buttons">
@@ -12,6 +12,8 @@
     <div style="margin: 10px 1px 5px 1px;">
       <span><em>{{localize "SWFFG.DicePoolAddsHint"}}</em></span>
     </div>
+    <details>
+    <summary>Fixed Results</summary>
     <table class="pool-additional-container">
       <tr>
         <td class="pool-additional">{{{ffgDiceSymbols "[SU]"}}}</td>
@@ -52,6 +54,7 @@
       </tr>
       {{/if}}
     </table>
+    </details>
     <table class="pool-dice-pool">
       <tr class="pool-container flex-group-center">
         <td><img src="systems/starwarsffg/images/dice/starwars/yellow.png" width="30" height="30" /></td>
@@ -107,6 +110,8 @@
       </tr>
       {{/if}}
     </table>
+    <details>
+    <summary>Options</summary>
     <div class="pool-roll-options">
       {{#if (or (eq isGM true) (eq canUserAddAudio true)) }}
       <div class="flexrow">
@@ -133,6 +138,7 @@
       </div>
       {{/if}}
     </div>
+    </details>
     <div class="roll-button flexrow">
       <button class="btn">{{localize "SWFFG.SkillsRoll"}}</button>
     </div>


### PR DESCRIPTION
Fix from @BoltsJ to make the roll window collapse in certain parts to keep the roll button accessible. Issue #958