### PR TITLE
fix(minions): display talents for minions

### DIFF
--- a/templates/parts/actor/ffg-talents.html
+++ b/templates/parts/actor/ffg-talents.html
@@ -8,7 +8,6 @@
     {{/if}}
     <div></div>
   </li>
-
   <ul class="items-list">
     {{#each talentList as |item id|}}
     <li class="item specialization-talent-item flexrow" data-item-id="{{item.itemId}}">
@@ -23,6 +22,21 @@
       <div class="item-controls">
         <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
         <a class="item-control item-info" title="Item Information"><i class="fas fa-info-circle"></i></a>
+      </div>
+    </li>
+    {{/each}}
+    {{#each data.talentList as |item id|}}
+    <li class="item specialization-talent-item flexrow" data-item-id="{{item.itemId}}">
+      <div class="item-name">
+        {{item.name}}
+      </div>
+      <div>{{localize item.activationLabel}}</div>
+      <div>{{item.rank}}</div>
+      {{#if (ne ../this.FFG.theme "starwars" )}}
+      <div>{{item.tier}}</div>
+      {{/if}}
+      <div class="item-controls">
+        <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
       </div>
     </li>
     {{/each}}

--- a/templates/parts/actor/ffg-talents.html
+++ b/templates/parts/actor/ffg-talents.html
@@ -30,7 +30,7 @@
       <div class="item-name">
         {{item.name}}
       </div>
-      <div>{{localize item.activationLabel}}</div>
+      <div>{{localize item.activation}}</div>
       <div>{{item.rank}}</div>
       {{#if (ne ../this.FFG.theme "starwars" )}}
       <div>{{item.tier}}</div>


### PR DESCRIPTION
#1110

for some reason, the talentList coming in from minions is in `data.talentList`, while it's `talentList` for PCs/rivals. Rather than spend a bunch of time debugging this, I just added a new block to handle it