### PR TITLE
fix(actors): correct sheet options not displaying

### DIFF
--- a/modules/actors/actor-ffg-options.js
+++ b/modules/actors/actor-ffg-options.js
@@ -6,12 +6,12 @@ export default class ActorOptions {
   }
 
   init(html) {
-    const options = $(`#ActorSheetFFG-Actor-${this.data.object.id} .ffg-sheet-options`);
-    if (options.length === 0) {
-      const button = $(`<a class="ffg-sheet-options"><i class="fas fa-wrench"></i>${game.i18n.localize("SWFFG.SheetOptions")}</a>`);
-      button.insertBefore(`#ActorSheetFFG-Actor-${this.data.object.id} header a:first`);
-      button.on("click", this.handler.bind(this));
-    }
+      const options = $(`.starwarsffg.sheet.actor[data-appid='${this.data.appId}'] .ffg-sheet-options`);
+      if (options.length === 0) {
+        const button = $(`<a class="ffg-sheet-options"><i class="fas fa-wrench"></i>${game.i18n.localize("SWFFG.SheetOptions")}</a>`);
+        button.insertBefore(`.starwarsffg.sheet.actor[data-appid='${this.data.appId}'] header a:first`);
+        button.on("click", this.handler.bind(this));
+      }
   }
 
   handler(event) {

--- a/templates/actors/ffg-character-sheet.html
+++ b/templates/actors/ffg-character-sheet.html
@@ -57,11 +57,11 @@
       {{!-- Primary Stats Container --}}
       <div class="container" style="flex-wrap: nowrap;{{#if limited}}display:none;{{/if}}">
         <div class="container flex-group-center">
-          {{!-- Wounds Box --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="split" title="SWFFG.Wounds" fields=(array (object name="data.stats.wounds.max" value=data.stats.wounds.max type="Number" label="SWFFG.Threshold") (object name="data.stats.wounds.value" value=data.stats.wounds.value type="Number" label="SWFFG.Current") ))}} 
-          {{#if (or (eq actor.flags.config.enableStrainThreshold undefined) (eq actor.flags.config.enableStrainThreshold true) )}}
-          {{!-- Strain Box --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="split" title="SWFFG.Strain" fields=(array (object name="data.stats.strain.max" value=data.stats.strain.max type="Number" label="SWFFG.Threshold") (object name="data.stats.strain.value" value=data.stats.strain.value type="Number" label="SWFFG.Current") ))}} 
+          {{!-- Wounds Box --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="split" title="SWFFG.Wounds" fields=(array (object name="data.stats.wounds.max" value=data.stats.wounds.max type="Number" label="SWFFG.Threshold") (object name="data.stats.wounds.value" value=data.stats.wounds.value type="Number" label="SWFFG.Current") ))}}
+          {{#if (or (eq actor.flags.starwarsffg.config.enableStrainThreshold undefined) (eq actor.flags.starwarsffg.config.enableStrainThreshold true) )}}
+          {{!-- Strain Box --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="split" title="SWFFG.Strain" fields=(array (object name="data.stats.strain.max" value=data.stats.strain.max type="Number" label="SWFFG.Threshold") (object name="data.stats.strain.value" value=data.stats.strain.value type="Number" label="SWFFG.Current") ))}}
           {{/if}}
-          {{!-- Soak Box --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.Soak" type="Number" name="data.stats.soak.value" value=data.stats.soak.value disabled=this.settings.enableSoakCalculation)}} 
+          {{!-- Soak Box --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.Soak" type="Number" name="data.stats.soak.value" value=data.stats.soak.value disabled=this.settings.enableSoakCalculation)}}
           {{!-- Defence Box --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="split" title="SWFFG.Defense" fields=(array (object name="data.stats.defence.ranged" value=data.stats.defence.ranged type="Number" label="SWFFG.DefenseRanged") (object name="data.stats.defence.melee" value=data.stats.defence.melee type="Number" label="SWFFG.DefenseMelee") ))}}
         </div>
       </div>
@@ -95,7 +95,7 @@
     {{!-- Owned Items Tab --}}
     <div class="tab items" data-group="primary" data-tab="items">
       <div class="container flex-group-center item-values">
-        {{!-- Medical Box --}} {{> "systems/starwarsffg/templates/parts/actor/ffg-healingitem.html" (object title=actor.flags.config.medicalItemName name="data.stats.medical.uses" value=data.stats.medical.uses)}}
+        {{!-- Medical Box --}} {{> "systems/starwarsffg/templates/parts/actor/ffg-healingitem.html" (object title=actor.flags.starwarsffg.config.medicalItemName name="data.stats.medical.uses" value=data.stats.medical.uses)}}
         {{!-- Encumbrance Box --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="split" title="SWFFG.Encumbrance" fields=(array (object name="data.stats.encumbrance.max" value=data.stats.encumbrance.max type="Number" label="SWFFG.Threshold") (object name="data.stats.encumbrance.value" value=data.stats.encumbrance.value type="Number" label="SWFFG.Current") ))}}
         {{!-- Credits Box --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="double" title="SWFFG.DescriptionCredits" type="String" name="data.stats.credits.value" value=data.stats.credits.value)}}
       </div>
@@ -108,9 +108,9 @@
     <div class="tab talents items" data-group="primary" data-tab="talents">
       {{!-- Talents List --}}
       <div class="container flex-group-center item-values">
-        {{!-- Force Box --}} {{#if (or (eq actor.flags.config.enableForcePool undefined) (eq actor.flags.config.enableForcePool true) )}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="split" title="SWFFG.ForcePool" fields=(array (object name="data.stats.forcePool.value" value=data.stats.forcePool.value type="Number" label="SWFFG.ForcePoolCommitted") (object name="data.stats.forcePool.max" value=data.stats.forcePool.max type="Number" label="SWFFG.ForcePoolAvailable") ))}} {{/if}}
+        {{!-- Force Box --}} {{#if (or (eq actor.flags.starwarsffg.config.enableForcePool undefined) (eq actor.flags.starwarsffg.config.enableForcePool true) )}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="split" title="SWFFG.ForcePool" fields=(array (object name="data.stats.forcePool.value" value=data.stats.forcePool.value type="Number" label="SWFFG.ForcePoolCommitted") (object name="data.stats.forcePool.max" value=data.stats.forcePool.max type="Number" label="SWFFG.ForcePoolAvailable") ))}} {{/if}}
       </div>
-      {{> "systems/starwarsffg/templates/parts/actor/ffg-talents.html"}} {{!-- Force Powers List --}} {{#if (or (eq actor.flags.config.enableForcePool undefined) (eq actor.flags.config.enableForcePool true) )}} {{> "systems/starwarsffg/templates/parts/actor/ffg-forcepowers.html"}} {{/if}} {{> "systems/starwarsffg/templates/parts/actor/ffg-signatureability.html"}}
+      {{> "systems/starwarsffg/templates/parts/actor/ffg-talents.html"}} {{!-- Force Powers List --}} {{#if (or (eq actor.flags.starwarsffg.config.enableForcePool undefined) (eq actor.flags.starwarsffg.config.enableForcePool true) )}} {{> "systems/starwarsffg/templates/parts/actor/ffg-forcepowers.html"}} {{/if}} {{> "systems/starwarsffg/templates/parts/actor/ffg-signatureability.html"}}
     </div>
 
     {{!-- Biography Tab --}}
@@ -123,7 +123,7 @@
         {{> "systems/starwarsffg/templates/parts/actor/ffg-criticalinjury.html" type="criticalinjury"}} {{!-- Experience Box --}}
 
         <div class="grid bio-grid">
-          {{!-- Experience Box --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="split" title="SWFFG.DescriptionXP" fields=(array (object name="data.experience.available" value=data.experience.available type="Number" label="SWFFG.DescriptionXPAvailable") (object name="data.experience.total" value=data.experience.total type="Number" label="SWFFG.DescriptionXPTotal") ))}} {{!-- Obligation Box --}} {{#if (or (eq actor.flags.config.enableObligation undefined) (eq actor.flags.config.enableObligation true) )}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionObligation" headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'" type="Number" name="data.obligation.value" value=data.obligation.value )}} {{/if}} {{!-- Duty Box --}} {{#if (or (eq actor.flags.config.enableDuty undefined) (eq actor.flags.config.enableDuty true) )}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionDuty" type="Number" name="data.duty.value" value=data.duty.value headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'")}} {{/if}} {{!-- Morality Box --}} {{#if (or (eq actor.flags.config.enableMorality undefined) (eq actor.flags.config.enableMorality true) )}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionMorality" type="Number" name="data.morality.value" value=data.morality.value headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'" )}} {{/if}} {{!-- Conflict Box --}} {{#if (or (eq actor.flags.config.enableConflict undefined) (eq actor.flags.config.enableConflict true) )}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionConflict" type="Number" name="data.conflict.value" value=data.conflict.value headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'" )}} {{/if}}
+          {{!-- Experience Box --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="split" title="SWFFG.DescriptionXP" fields=(array (object name="data.experience.available" value=data.experience.available type="Number" label="SWFFG.DescriptionXPAvailable") (object name="data.experience.total" value=data.experience.total type="Number" label="SWFFG.DescriptionXPTotal") ))}} {{!-- Obligation Box --}} {{#if (or (eq actor.flags.starwarsffg.config.enableObligation undefined) (eq actor.flags.starwarsffg.config.enableObligation true) )}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionObligation" headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'" type="Number" name="data.obligation.value" value=data.obligation.value )}} {{/if}} {{!-- Duty Box --}} {{#if (or (eq actor.flags.starwarsffg.config.enableDuty undefined) (eq actor.flags.starwarsffg.config.enableDuty true) )}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionDuty" type="Number" name="data.duty.value" value=data.duty.value headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'")}} {{/if}} {{!-- Morality Box --}} {{#if (or (eq actor.flags.starwarsffg.config.enableMorality undefined) (eq actor.flags.starwarsffg.config.enableMorality true) )}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionMorality" type="Number" name="data.morality.value" value=data.morality.value headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'" )}} {{/if}} {{!-- Conflict Box --}} {{#if (or (eq actor.flags.starwarsffg.config.enableConflict undefined) (eq actor.flags.starwarsffg.config.enableConflict true) )}} {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionConflict" type="Number" name="data.conflict.value" value=data.conflict.value headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'" )}} {{/if}}
         </div>
       </div>
     </div>
@@ -187,7 +187,7 @@
     </div>
 
     <div class="tab obligation" data-group="primary" data-tab="obligation">
-      {{#if (or (eq actor.flags.config.enableObligation undefined) (eq actor.flags.config.enableObligation true) )}}
+      {{#if (or (eq actor.flags.starwarsffg.config.enableObligation undefined) (eq actor.flags.starwarsffg.config.enableObligation true) )}}
       <div class="resource full">
         <div class="attribute flex-group-center">
           <div class="block-background">
@@ -217,7 +217,7 @@
           </div>
         </div>
       </div>
-      {{/if}} {{#if (or (eq actor.flags.config.enableDuty undefined) (eq actor.flags.config.enableDuty true) )}}
+      {{/if}} {{#if (or (eq actor.flags.starwarsffg.config.enableDuty undefined) (eq actor.flags.starwarsffg.config.enableDuty true) )}}
       <div class="resource full">
         <div class="attribute flex-group-center">
           <div class="block-background">
@@ -247,7 +247,7 @@
           </div>
         </div>
       </div>
-      {{/if}} {{#if (or (eq actor.flags.config.enableMorality undefined) (eq actor.flags.config.enableMorality true) )}}
+      {{/if}} {{#if (or (eq actor.flags.starwarsffg.config.enableMorality undefined) (eq actor.flags.starwarsffg.config.enableMorality true) )}}
       <div class="block-editor">
         {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="full" title="SWFFG.EmotionalStrength" type="PopoutEditor" name="data.morality.strength" value=data.morality.strength)}}
       </div>

--- a/templates/dialogs/ffg-sheet-options.html
+++ b/templates/dialogs/ffg-sheet-options.html
@@ -1,15 +1,16 @@
 <div class="dialog-content sheet-options-dialog">
+    {{{ json content }}}
   <form class="flexcol" autocomplete="off">
     {{#each content.options as |option id|}}
     <div class="form-group">
       <label>{{option.name}}</label>
       <div class="form-fields">
         {{#if (eq option.type "Boolean")}}
-        <input type="checkbox" name="flags.config.{{id}}" id="{{id}}" data-dtype="Boolean" {{checked option.value}} />
+        <input type="checkbox" name="flags.starwarsffg.config.{{id}}" id="{{id}}" data-dtype="Boolean" {{checked option.value}} />
         {{/if}} {{#if (eq option.type "String")}}
-        <input type="text" name="flags.config.{{id}}" id="{{id}}" data-dtype="String" value="{{localize option.value}}" />
+        <input type="text" name="flags.starwarsffg.config.{{id}}" id="{{id}}" data-dtype="String" value="{{localize option.value}}" />
         {{/if}} {{#if (eq option.type "Array")}}
-        <select name="flags.config.{{id}}" id="{{id}}">
+        <select name="flags.starwarsffg.config.{{id}}" id="{{id}}">
           {{#select option.value }}{{#each option.options as |optionvalue id| }}
           <option value="{{id}}">{{optionvalue}}</option>
           {{/each}}{{/select}}

--- a/templates/dialogs/ffg-sheet-options.html
+++ b/templates/dialogs/ffg-sheet-options.html
@@ -1,5 +1,4 @@
 <div class="dialog-content sheet-options-dialog">
-    {{{ json content }}}
   <form class="flexcol" autocomplete="off">
     {{#each content.options as |option id|}}
     <div class="form-group">


### PR DESCRIPTION
migrate flag setting and lookup (v10 introduced name spaced flags and we didn't fully port all of them for actors)

#1113