### PR TITLE
Change a .system call back to .data in SWA importer

### DIFF
--- a/modules/importer/swa-importer.js
+++ b/modules/importer/swa-importer.js
@@ -627,7 +627,7 @@ export default class SWAImporter extends FormApplication {
                           };
                           const descriptor = new CONFIG.Item.documentClass(unique, { temporary: true });
                           descriptor.system._id = randomID();
-                          templatedData.system.itemmodifier.push(descriptor.system);
+                          templatedData.system.itemmodifier.push(descriptor.data);
                         });
                       }
 


### PR DESCRIPTION
Fix for #1139

I believe someone got a little over eager to change `.data` to `.system`.

After reviewing the oggDude importer this brings it back to matching that.