### PR TITLE
style(dice): correct expanded roll card size

### DIFF
--- a/styles/starwarsffg.css
+++ b/styles/starwarsffg.css
@@ -1127,6 +1127,10 @@ img {
   width: 40px;
   float: left;
 }
+.starwarsffg .dice-tooltip .dice-rolls .roll {
+  width: 24px;
+  float: left;
+}
 .starwarsffg .dice-result .roll-success {
   color: darkgreen;
 }


### PR DESCRIPTION
fixes #1194

v9

![image](https://user-images.githubusercontent.com/4709746/219983215-0022d096-273e-4e1a-942d-be62917532f7.png)


current fix

![image](https://user-images.githubusercontent.com/4709746/219983235-4fb17a29-bc5e-42ab-b6c2-003b09b9e745.png)
