### PR TITLE
Fix update of compendium entries with OggDude Import in Foundry v10

### DIFF
--- a/modules/importer/import-helpers.js
+++ b/modules/importer/import-helpers.js
@@ -2218,6 +2218,7 @@ export default class ImportHelpers {
       const crt = await pack.importDocument(compendiumItem);
       CONFIG.temporary[pack.collection][data.flags.starwarsffg.ffgimportid] = duplicate(crt);
     } else {
+      CONFIG.logger.debug(`Found existing ${type} ${dataType} ${data.name} : ${JSON.stringify(entry)}`);
       let upd;
       if (removeFirst) {
         await pack.delete(entry.id);

--- a/modules/importer/import-helpers.js
+++ b/modules/importer/import-helpers.js
@@ -173,7 +173,7 @@ export default class ImportHelpers {
 
           const content = await pack.getDocuments();
           for (var i = 0; i < content.length; i++) {
-            CONFIG.temporary[packid][content[i].flags?.starwarsffg?.ffgimportid] = duplicate(content[i]);
+            CONFIG.temporary[packid][content[i].flags?.starwarsffg?.ffgimportid] = deepClone(content[i]);
           }
         }
       } else {

--- a/modules/importer/import-helpers.js
+++ b/modules/importer/import-helpers.js
@@ -2254,7 +2254,11 @@ export default class ImportHelpers {
         }
 
         CONFIG.logger.debug(`Updating ${type} ${dataType} ${data.name} : ${JSON.stringify(updateData)}`);
-        await pack.get(updateData._id)?.update(updateData);
+        try {
+          await pack.get(updateData._id).update(updateData);
+        } catch (e) {
+          CONFIG.logger.error(`Failed to update ${type} ${dataType} ${data.name} : ${e.toString()}`);
+        }
         upd = duplicate(entry);
         if (upd.data) {
           upd.data = mergeObject(upd.data, data.data);


### PR DESCRIPTION
This PR fixes update of compendium entries when reimporting changes from OggDude over already existing compendia.

After installing StarWarsFFG into a new Foundry v10 install I found out that updating the stock OggDude data with my texts input via the OggDude Data Editor no longer worked in Foundry v10 although the console did not report any errors. In order to fix this I made the following changes:
- Detect and log failed updates
- Log existing compendium entry to make it easier to spot problems when debugging
- Fix the update issue by switching pack caching from `duplicate` to `deepClone` usage

In case you only want some of these changes merged I provided them in separate commits.

My first approach to fixing the issue was to switch back from the non-existing `id` property to the existing `_id` property here:
https://github.com/StarWarsFoundryVTT/StarWarsFFG/blob/692537d45a765f961117aa9ba25b48c83f8b5f1d/modules/importer/import-helpers.js#L2245

While this worked as well, it did not feel right, so I looked for a way to keep using the public API. It turned out that here
https://github.com/StarWarsFoundryVTT/StarWarsFFG/blob/692537d45a765f961117aa9ba25b48c83f8b5f1d/modules/importer/import-helpers.js#L174-L177
we actually got functioning instances from the API, in my specific case instances of `ItemFFG`. As those were real instances of the class, one could get the entry id with the `id` getter defined on them. After running `duplicate()` on the entry, only the properties remained as a bare object. Once I changed this part to use `deepClone()` the copies of the entries were usable as `ItemFFG` instances again, thus also allowing me to use the `id` getter. Interestingly enough the API documentation says that `deepClone()` does not support advanced object types, but I'll gladly accept that it does.
As a side effect of now having `ItemFFG` instances instead of plain objects, the console also started to warn me about other locations in the code that still use the pre-v10 Data Model access and should be updated (from what I've read there will be backwards-compatible support until v12, starting v13 those warnings will become errors).
So I think while this fix is somewhat more tinkering with the insides of the system, it should be a more stable way going forward in Foundry v10 support. If you want to play it safe, we could still fix it by switching from `entry.id` to `entry._id`.