### PR TITLE
Fix update of talent information on actors

### DIFF
--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -1320,9 +1320,13 @@ export class ActorSheetFFG extends ActorSheet {
       return item.type === "specialization";
     });
 
+    CONFIG.logger.debug(`_updateSpecialization(): data.talentList before we start:`);
+    CONFIG.logger.debug(data.talentList.slice());
+
     const globalTalentList = [];
 
     for await (const spec of specializations) {
+      CONFIG.logger.debug(`_updateSpecialization(): starting work on ${spec.name}`);
       const specializationTalents = spec.system.talents;
       for (const talent in specializationTalents) {
         let gameItem;
@@ -1367,6 +1371,8 @@ export class ActorSheetFFG extends ActorSheet {
           }
         });
       }
+      CONFIG.logger.debug(`_updateSpecialization(): globalTalentList after current specialization:`);
+      CONFIG.logger.debug(globalTalentList.slice());
     }
 
     data.talentList = globalTalentList.sort((a, b) => {
@@ -1374,6 +1380,9 @@ export class ActorSheetFFG extends ActorSheet {
       if (a.name < b.name) return -1;
       return 0;
     });
+
+    CONFIG.logger.debug(`_updateSpecialization(): data.talentList after update:`);
+    CONFIG.logger.debug(data.talentList.slice());
   }
 
   /**

--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -1320,6 +1320,8 @@ export class ActorSheetFFG extends ActorSheet {
       return item.type === "specialization";
     });
 
+    const globalTalentList = [];
+
     for await (const spec of specializations) {
       const specializationTalents = spec.system.talents;
       for (const talent in specializationTalents) {
@@ -1343,7 +1345,6 @@ export class ActorSheetFFG extends ActorSheet {
         }
       }
 
-      const globalTalentList = [];
       if (spec?.talentList && spec.talentList.length > 0) {
         spec.talentList.forEach((talent) => {
           const item = talent;
@@ -1366,8 +1367,13 @@ export class ActorSheetFFG extends ActorSheet {
           }
         });
       }
-      data.talentList = mergeObject(data.talentList ? data.talentList : [], globalTalentList);
     }
+
+    data.talentList = globalTalentList.sort((a, b) => {
+      if (a.name > b.name) return 1;
+      if (a.name < b.name) return -1;
+      return 0;
+    });
   }
 
   /**


### PR DESCRIPTION
The previous implementation looped through all specializations and created a list of selected talents from each specialization, applying the updates to the actor's talent list after each individual specialization. Unfortunately the used `mergeObject()` function does not try to match the talents by name and then replace the appropriate ones, but simply overwrites the array from the beginning. Thus the beginning of the talent list is overwritten up to the maximum selected entries of a single specialization and the remainder of the talent list remains unchanged.
To avoid this, the new implementation constructs a new talent list over all specializations and then sets it as the new talent list once at the end. This approach also fixes another previously unreported bug since handling each specialization separately also miscalculated talent ranks of talents that have been selected in more than one specialization.

Fixes #1226