### PR TITLE
Keep alphabetic order of talents in activation groups

### DIFF
--- a/modules/actors/actor-ffg.js
+++ b/modules/actors/actor-ffg.js
@@ -285,7 +285,7 @@ export class ActorFFG extends Actor {
 
     // enable talent sorting if global to true and sheet is set to inherit or sheet is set to true.
     if ((game.settings.get("starwarsffg", "talentSorting") && (!actorData.flags?.config?.talentSorting || actorData.flags?.config?.talentSorting === "0")) || actorData.flags?.config?.talentSorting === "1") {
-      data.talentList = globalTalentList.slice().sort(this._sortTalents);
+      data.talentList = globalTalentList.slice().reverse().sort(this._sortTalents);
     } else {
       data.talentList = globalTalentList;
     }


### PR DESCRIPTION
Sorting talents grouped by activation would reverse the alphabetic sorting of the talent names in an activation group to be descending.
This commit changes the sorting to be grouped by activation and alphabetically ascending by talent name in each activation group.