### PR TITLE
Fix NPE during legacy item initiation

### DIFF
--- a/modules/helpers/item-helpers.js
+++ b/modules/helpers/item-helpers.js
@@ -73,7 +73,9 @@ export default class ItemHelpers {
 
       }
     } catch (error) {
-        await this.object.update(formData);
+      CONFIG.logger.debug(`Encountered an error while trying to update item ${this.object.id}`);
+      CONFIG.logger.debug(error);
+      await this.object.update(formData);
     }
 
     if (this.object.type === "talent") {

--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -121,7 +121,7 @@ export class ItemFFG extends ItemBaseFFG {
 
         if (data?.itemattachment) {
           data.itemattachment.forEach((attachment) => {
-            const activeModifiers = attachment.system?.itemmodifier?.filter((i) => i.system?.active) || [];
+            const activeModifiers = attachment.system?.itemmodifier?.filter((i) => i?.system?.active) || [];
             data.damage.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "damage", "Weapon Stat");
             data.crit.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "critical", "Weapon Stat");
             if (data.crit.adjusted < 1) data.crit.adjusted = 1;
@@ -211,7 +211,7 @@ export class ItemFFG extends ItemBaseFFG {
 
         if (data?.itemattachment) {
           data.itemattachment.forEach((attachment) => {
-            const activeModifiers = attachment.system?.itemmodifier?.filter((i) => i.system?.active) || [];
+            const activeModifiers = attachment.system?.itemmodifier?.filter((i) => i?.system?.active) || [];
             data.soak.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "soak", "Armor Stat");
             data.defence.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "defence", "Armor Stat");
             data.encumbrance.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "encumbrance", "Armor Stat");

--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -121,7 +121,7 @@ export class ItemFFG extends ItemBaseFFG {
 
         if (data?.itemattachment) {
           data.itemattachment.forEach((attachment) => {
-            const activeModifiers = attachment.system.itemmodifier.filter((i) => i.system?.active);
+            const activeModifiers = attachment.system?.itemmodifier?.filter((i) => i.system?.active) || [];
             data.damage.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "damage", "Weapon Stat");
             data.crit.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "critical", "Weapon Stat");
             if (data.crit.adjusted < 1) data.crit.adjusted = 1;
@@ -211,7 +211,7 @@ export class ItemFFG extends ItemBaseFFG {
 
         if (data?.itemattachment) {
           data.itemattachment.forEach((attachment) => {
-            const activeModifiers = attachment.system.itemmodifier.filter((i) => i.system?.active);
+            const activeModifiers = attachment.system?.itemmodifier?.filter((i) => i.system?.active) || [];
             data.soak.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "soak", "Armor Stat");
             data.defence.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "defence", "Armor Stat");
             data.encumbrance.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "encumbrance", "Armor Stat");

--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -284,7 +284,7 @@ export class ItemFFG extends ItemBaseFFG {
 
       if (data?.itemattachment?.length) {
         data.itemattachment.forEach((attachment) => {
-          totalHPUsed += attachment.system.hardpoints.value;
+          totalHPUsed += attachment.system?.hardpoints?.value || 0;
         });
       }
 

--- a/modules/swffg-main.js
+++ b/modules/swffg-main.js
@@ -561,6 +561,10 @@ Hooks.on("dropActorSheetData", (...args) => {
     register_crew(...args);
 });
 
+function isCurrentVersionNullOrBlank(currentVersion) {
+  return currentVersion === "null" || currentVersion === '' || currentVersion === null;
+}
+
 // Handle migration duties
 Hooks.once("ready", async () => {
   SettingsHelpers.readyLevelSetting();
@@ -586,7 +590,7 @@ Hooks.once("ready", async () => {
     d.render(true);
   }
 
-  if ((isAlpha || currentVersion === "null" || currentVersion === '' || parseFloat(currentVersion) < parseFloat(game.system.version)) && game.user.isGM) {
+  if ((isAlpha || isCurrentVersionNullOrBlank(currentVersion) || parseFloat(currentVersion) < parseFloat(game.system.version)) && game.user.isGM) {
     CONFIG.logger.log(`Migrating to from ${currentVersion} to ${game.system.version}`);
 
     // Calculating wound and strain .value from .real_value is no longer necessary due to the Token._drawBar() override in swffg-main.js
@@ -637,7 +641,7 @@ Hooks.once("ready", async () => {
       }
     });
 
-    if (isAlpha || currentVersion === "null" || currentVersion === '' || parseFloat(currentVersion) < 1.1) {
+    if (isAlpha || isCurrentVersionNullOrBlank(currentVersion) || parseFloat(currentVersion) < 1.1) {
       // Migrate alternate skill lists from file if found
       try {
         let skillList = [];
@@ -687,7 +691,7 @@ Hooks.once("ready", async () => {
       }
     }
     // migrate embedded items
-    if (isAlpha || currentVersion === "null" || currentVersion === '' || parseFloat(currentVersion) < 1.8) {
+    if (isAlpha || isCurrentVersionNullOrBlank(currentVersion) || parseFloat(currentVersion) < 1.8) {
       ui.notifications.info(`Migrating Star Wars FFG System Deep Embedded Items`);
       CONFIG.logger.debug('Migrating Star Wars FFG System Deep Embedded Items');
 
@@ -752,7 +756,7 @@ Hooks.once("ready", async () => {
     }
 
     // migrate compendiums and flags
-    if (isAlpha || currentVersion === "null" || currentVersion === '' || parseFloat(currentVersion) < 1.61) {
+    if (isAlpha || isCurrentVersionNullOrBlank(currentVersion) || parseFloat(currentVersion) < 1.61) {
       ui.notifications.info(`Migrating Starwars FFG System for version ${game.system.version}. Please be patient and do not close your game or shut down your server.`, { permanent: true });
 
       try {


### PR DESCRIPTION
Handle cases where legacy item attachments do not have a `system` property and therefore blow up the system initiation phase before migrations can run to repair the underlying data structure.