### PR TITLE
Fix issue 1219: adding multiple of qualities appends rank instead of sum

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -491,6 +491,7 @@
   "SWFFG.ModTypeAddSuccess": "Erfolg hinzufügen",
   "SWFFG.ModTypeAddThreat": "Bedrohung hinzufügen",
   "SWFFG.ModTypeStatArmor": "Rüstungswert",
+  "SWFFG.ModTypeStatVehicle": "Fahrzügwert",
   "SWFFG.FromAttachment": "von Anpassung",
   "SWFFG.WeaponCardCritical": "Kritisch",
   "SWFFG.ItemModifiers": "Item Modifikatoren",

--- a/lang/en.json
+++ b/lang/en.json
@@ -530,6 +530,7 @@
   "SWFFG.ModTypeAddSuccess": "Add Success",
   "SWFFG.ModTypeAddThreat": "Add Threat",
   "SWFFG.ModTypeStatArmor" : "Armor Stat",
+  "SWFFG.ModTypeStatVehicle": "Vehicle Stat",
   "SWFFG.FromAttachment": "From Attachment",
   "SWFFG.WeaponCardCritical" : "Critical",
   "SWFFG.ItemModifiers" : "Item Modifiers",

--- a/lang/es.json
+++ b/lang/es.json
@@ -511,6 +511,7 @@
   "SWFFG.ModTypeAddSuccess": "Añade Éxito",
   "SWFFG.ModTypeAddThreat": "Añade Amenaza",
   "SWFFG.ModTypeStatArmor" : "Atr. Armadura",
+  "SWFFG.ModTypeStatVehicle": "Atr. Veículo",
   "SWFFG.FromAttachment": "De Accesorio",
   "SWFFG.WeaponCardCritical" : "Crítico",
   "SWFFG.ItemModifiers" : "Modificador Objeto",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -491,6 +491,7 @@
   "SWFFG.ModTypeAddSuccess": "Ajouter un Succès",
   "SWFFG.ModTypeAddThreat": "Ajouter un Menace",
   "SWFFG.ModTypeStatArmor": "État de l'armure",
+  "SWFFG.ModTypeStatVehicle": "État de le véhicule",
   "SWFFG.FromAttachment": "De l'Attachement",
   "SWFFG.WeaponCardCritical": "Critique",
   "SWFFG.ItemModifiers": "Modificateurs d'objet",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -491,6 +491,7 @@
   "SWFFG.ModTypeAddSuccess": "Adicionar Sucesso",
   "SWFFG.ModTypeAddThreat": "Adicionar Ameaça",
   "SWFFG.ModTypeStatArmor" : "Stat da Armdaura",
+  "SWFFG.ModTypeStatVehicle": "Stat da Veículo",
   "SWFFG.FromAttachment": "do acessório",
   "SWFFG.WeaponCardCritical" : "Crítico",
   "SWFFG.ItemModifiers" : "Modificadores de items",

--- a/modules/config/ffg-modifiers.js
+++ b/modules/config/ffg-modifiers.js
@@ -135,6 +135,10 @@ export const itemmodifier_modifiertypes = {
     "value": "Armor Stat",
     "label": "SWFFG.ModTypeStatArmor",
   }, //-> Def, Soak, Encum, HP, Rarity, Price
+  "Vehicle Stat": {
+    "value": "Vehicle Stat",
+    "label": "SWFFG.ModTypeStatVehicle",
+  },
 };
 
 export const itemmodifier_rollmodifiers = {

--- a/modules/helpers/item-helpers.js
+++ b/modules/helpers/item-helpers.js
@@ -73,7 +73,9 @@ export default class ItemHelpers {
 
       }
     } catch (error) {
-        await this.object.update(formData);
+      CONFIG.logger.debug(`Encountered an error while trying to update item ${this.object.id}`);
+      CONFIG.logger.debug(error);
+      await this.object.update(formData);
     }
 
     if (this.object.type === "talent") {

--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -121,7 +121,7 @@ export class ItemFFG extends ItemBaseFFG {
 
         if (data?.itemattachment) {
           data.itemattachment.forEach((attachment) => {
-            const activeModifiers = attachment.system.itemmodifier.filter((i) => i.system?.active);
+            const activeModifiers = attachment.system?.itemmodifier?.filter((i) => i?.system?.active) || [];
             data.damage.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "damage", "Weapon Stat");
             data.crit.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "critical", "Weapon Stat");
             if (data.crit.adjusted < 1) data.crit.adjusted = 1;
@@ -211,7 +211,7 @@ export class ItemFFG extends ItemBaseFFG {
 
         if (data?.itemattachment) {
           data.itemattachment.forEach((attachment) => {
-            const activeModifiers = attachment.system.itemmodifier.filter((i) => i.system?.active);
+            const activeModifiers = attachment.system?.itemmodifier?.filter((i) => i?.system?.active) || [];
             data.soak.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "soak", "Armor Stat");
             data.defence.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "defence", "Armor Stat");
             data.encumbrance.adjusted += ModifierHelpers.getCalculatedValueFromCurrentAndArray(attachment, activeModifiers, "encumbrance", "Armor Stat");
@@ -284,7 +284,7 @@ export class ItemFFG extends ItemBaseFFG {
 
       if (data?.itemattachment?.length) {
         data.itemattachment.forEach((attachment) => {
-          totalHPUsed += attachment.system.hardpoints.value;
+          totalHPUsed += attachment.system?.hardpoints?.value || 0;
         });
       }
 

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -877,7 +877,7 @@ export class ItemSheetFFG extends ItemSheet {
           }
 
           if (foundItem && this.object.type !== "itemattachment") {
-            foundItem.system.rank += itemObject.system.rank;
+            foundItem.system.rank = (parseInt(foundItem.system.rank) + parseInt(itemObject.system.rank)).toString();
           } else {
             items.push(itemObject);
           }

--- a/modules/swffg-main.js
+++ b/modules/swffg-main.js
@@ -561,6 +561,10 @@ Hooks.on("dropActorSheetData", (...args) => {
     register_crew(...args);
 });
 
+function isCurrentVersionNullOrBlank(currentVersion) {
+  return currentVersion === "null" || currentVersion === '' || currentVersion === null;
+}
+
 // Handle migration duties
 Hooks.once("ready", async () => {
   SettingsHelpers.readyLevelSetting();
@@ -586,7 +590,7 @@ Hooks.once("ready", async () => {
     d.render(true);
   }
 
-  if ((isAlpha || currentVersion === "null" || currentVersion === '' || parseFloat(currentVersion) < parseFloat(game.system.version)) && game.user.isGM) {
+  if ((isAlpha || isCurrentVersionNullOrBlank(currentVersion) || parseFloat(currentVersion) < parseFloat(game.system.version)) && game.user.isGM) {
     CONFIG.logger.log(`Migrating to from ${currentVersion} to ${game.system.version}`);
 
     // Calculating wound and strain .value from .real_value is no longer necessary due to the Token._drawBar() override in swffg-main.js
@@ -637,7 +641,7 @@ Hooks.once("ready", async () => {
       }
     });
 
-    if (isAlpha || currentVersion === "null" || currentVersion === '' || parseFloat(currentVersion) < 1.1) {
+    if (isAlpha || isCurrentVersionNullOrBlank(currentVersion) || parseFloat(currentVersion) < 1.1) {
       // Migrate alternate skill lists from file if found
       try {
         let skillList = [];
@@ -687,7 +691,7 @@ Hooks.once("ready", async () => {
       }
     }
     // migrate embedded items
-    if (isAlpha || currentVersion === "null" || currentVersion === '' || parseFloat(currentVersion) < 1.8) {
+    if (isAlpha || isCurrentVersionNullOrBlank(currentVersion) || parseFloat(currentVersion) < 1.8) {
       ui.notifications.info(`Migrating Star Wars FFG System Deep Embedded Items`);
       CONFIG.logger.debug('Migrating Star Wars FFG System Deep Embedded Items');
 
@@ -752,7 +756,7 @@ Hooks.once("ready", async () => {
     }
 
     // migrate compendiums and flags
-    if (isAlpha || currentVersion === "null" || currentVersion === '' || parseFloat(currentVersion) < 1.61) {
+    if (isAlpha || isCurrentVersionNullOrBlank(currentVersion) || parseFloat(currentVersion) < 1.61) {
       ui.notifications.info(`Migrating Starwars FFG System for version ${game.system.version}. Please be patient and do not close your game or shut down your server.`, { permanent: true });
 
       try {

--- a/templates/parts/shared/ffg-modifiers.html
+++ b/templates/parts/shared/ffg-modifiers.html
@@ -15,10 +15,11 @@
       <option value="{{t.value}}">{{localize t.label}}</option>
       {{/each}} {{/if}} {{#if (eq ../item.type "weapon")}} {{#each ../this.FFG.weapon_mod_types as |t|}}
       <option value="{{t.value}}">{{localize t.label}}</option>
-      {{/each}} {{/if}} {{#if (or (eq ../item.type "itemmodifier") (eq ../item.type "itemattachment"))}} {{#each ../this.FFG.itemmodifier_mod_types as |t|}} {{#if (eq ../item.type "all")}}<option value="{{t.value}}">{{localize t.label}}</option>
-      {{else}} {{#if (and (eq ../../item.type "weapon") (eq t.value "Weapon Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
-      >{{/if}} {{#if (and (eq ../../item.type "armour") (eq t.value "Armor Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
-      >{{/if}} {{#if (and (ne t.value "Armor Stat") (ne t.value "Weapon Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
+      {{/each}} {{/if}} {{#if (or (eq ../item.type "itemmodifier") (eq ../item.type "itemattachment"))}} {{#each ../this.FFG.itemmodifier_mod_types as |t|}} {{#if (eq ../../item.system.type "all")}}<option value="{{t.value}}">{{localize t.label}}</option>
+      {{else}} {{#if (and (eq ../../item.system.type "weapon") (eq t.value "Weapon Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
+      >{{/if}} {{#if (and (eq ../../item.system.type "armour") (eq t.value "Armor Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
+      >{{/if}} {{#if (and (eq ../../item.system.type "vehicle") (eq t.value "Vehicle Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
+      >{{/if}} {{#if (and (ne t.value "Armor Stat") (ne t.value "Weapon Stat")(ne t.value "Vehicle Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
       >{{/if}} {{/if}} {{/each}} {{/if}} {{/select}}
     </select>
     <select class="attribute-mod" name="data.attributes.{{key}}.mod">
@@ -41,6 +42,8 @@
       {{/each}} {{/if}} {{#if (eq attr.modtype "Weapon Stat") }} {{#each ../this.FFG.weapon_stats as |t|}}
       <option value="{{t.value}}">{{localize t.label}}</option>
       {{/each}} {{/if}} {{#if (eq attr.modtype "Armor Stat") }} {{#each ../this.FFG.armor_stats as |t|}}
+      <option value="{{t.value}}">{{localize t.label}}</option>
+      {{/each}} {{/if}} {{#if (eq attr.modtype "Vehicle Stat") }} {{#each ../this.FFG.vehicle_stats as |t|}}
       <option value="{{t.value}}">{{localize t.label}}</option>
       {{/each}} {{/if}} {{/select}}
     </select>


### PR DESCRIPTION
Modifier ranks were being appended as strings. 1+1 would equal 11. Now
existing rank and modifier rank are parsed to ints, summed, and made
strings again for the item sheet. Remade rank back into a string to prevent
any regressions.

https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1219