### PR TITLE
Fix 1223: Missing modifier dropdowns

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -491,6 +491,7 @@
   "SWFFG.ModTypeAddSuccess": "Erfolg hinzufügen",
   "SWFFG.ModTypeAddThreat": "Bedrohung hinzufügen",
   "SWFFG.ModTypeStatArmor": "Rüstungswert",
+  "SWFFG.ModTypeStatVehicle": "Fahrzügwert",
   "SWFFG.FromAttachment": "von Anpassung",
   "SWFFG.WeaponCardCritical": "Kritisch",
   "SWFFG.ItemModifiers": "Item Modifikatoren",

--- a/lang/en.json
+++ b/lang/en.json
@@ -530,6 +530,7 @@
   "SWFFG.ModTypeAddSuccess": "Add Success",
   "SWFFG.ModTypeAddThreat": "Add Threat",
   "SWFFG.ModTypeStatArmor" : "Armor Stat",
+  "SWFFG.ModTypeStatVehicle": "Vehicle Stat",
   "SWFFG.FromAttachment": "From Attachment",
   "SWFFG.WeaponCardCritical" : "Critical",
   "SWFFG.ItemModifiers" : "Item Modifiers",

--- a/lang/es.json
+++ b/lang/es.json
@@ -511,6 +511,7 @@
   "SWFFG.ModTypeAddSuccess": "Añade Éxito",
   "SWFFG.ModTypeAddThreat": "Añade Amenaza",
   "SWFFG.ModTypeStatArmor" : "Atr. Armadura",
+  "SWFFG.ModTypeStatVehicle": "Atr. Veículo",
   "SWFFG.FromAttachment": "De Accesorio",
   "SWFFG.WeaponCardCritical" : "Crítico",
   "SWFFG.ItemModifiers" : "Modificador Objeto",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -491,6 +491,7 @@
   "SWFFG.ModTypeAddSuccess": "Ajouter un Succès",
   "SWFFG.ModTypeAddThreat": "Ajouter un Menace",
   "SWFFG.ModTypeStatArmor": "État de l'armure",
+  "SWFFG.ModTypeStatVehicle": "État de le véhicule",
   "SWFFG.FromAttachment": "De l'Attachement",
   "SWFFG.WeaponCardCritical": "Critique",
   "SWFFG.ItemModifiers": "Modificateurs d'objet",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -491,6 +491,7 @@
   "SWFFG.ModTypeAddSuccess": "Adicionar Sucesso",
   "SWFFG.ModTypeAddThreat": "Adicionar Ameaça",
   "SWFFG.ModTypeStatArmor" : "Stat da Armdaura",
+  "SWFFG.ModTypeStatVehicle": "Stat da Veículo",
   "SWFFG.FromAttachment": "do acessório",
   "SWFFG.WeaponCardCritical" : "Crítico",
   "SWFFG.ItemModifiers" : "Modificadores de items",

--- a/modules/config/ffg-modifiers.js
+++ b/modules/config/ffg-modifiers.js
@@ -135,6 +135,10 @@ export const itemmodifier_modifiertypes = {
     "value": "Armor Stat",
     "label": "SWFFG.ModTypeStatArmor",
   }, //-> Def, Soak, Encum, HP, Rarity, Price
+  "Vehicle Stat": {
+    "value": "Vehicle Stat",
+    "label": "SWFFG.ModTypeStatVehicle",
+  },
 };
 
 export const itemmodifier_rollmodifiers = {

--- a/templates/parts/shared/ffg-modifiers.html
+++ b/templates/parts/shared/ffg-modifiers.html
@@ -15,10 +15,11 @@
       <option value="{{t.value}}">{{localize t.label}}</option>
       {{/each}} {{/if}} {{#if (eq ../item.type "weapon")}} {{#each ../this.FFG.weapon_mod_types as |t|}}
       <option value="{{t.value}}">{{localize t.label}}</option>
-      {{/each}} {{/if}} {{#if (or (eq ../item.type "itemmodifier") (eq ../item.type "itemattachment"))}} {{#each ../this.FFG.itemmodifier_mod_types as |t|}} {{#if (eq ../item.type "all")}}<option value="{{t.value}}">{{localize t.label}}</option>
-      {{else}} {{#if (and (eq ../../item.type "weapon") (eq t.value "Weapon Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
-      >{{/if}} {{#if (and (eq ../../item.type "armour") (eq t.value "Armor Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
-      >{{/if}} {{#if (and (ne t.value "Armor Stat") (ne t.value "Weapon Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
+      {{/each}} {{/if}} {{#if (or (eq ../item.type "itemmodifier") (eq ../item.type "itemattachment"))}} {{#each ../this.FFG.itemmodifier_mod_types as |t|}} {{#if (eq ../../item.system.type "all")}}<option value="{{t.value}}">{{localize t.label}}</option>
+      {{else}} {{#if (and (eq ../../item.system.type "weapon") (eq t.value "Weapon Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
+      >{{/if}} {{#if (and (eq ../../item.system.type "armour") (eq t.value "Armor Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
+      >{{/if}} {{#if (and (eq ../../item.system.type "vehicle") (eq t.value "Vehicle Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
+      >{{/if}} {{#if (and (ne t.value "Armor Stat") (ne t.value "Weapon Stat")(ne t.value "Vehicle Stat"))}}<option value="{{t.value}}">{{localize t.label}}</option
       >{{/if}} {{/if}} {{/each}} {{/if}} {{/select}}
     </select>
     <select class="attribute-mod" name="data.attributes.{{key}}.mod">
@@ -41,6 +42,8 @@
       {{/each}} {{/if}} {{#if (eq attr.modtype "Weapon Stat") }} {{#each ../this.FFG.weapon_stats as |t|}}
       <option value="{{t.value}}">{{localize t.label}}</option>
       {{/each}} {{/if}} {{#if (eq attr.modtype "Armor Stat") }} {{#each ../this.FFG.armor_stats as |t|}}
+      <option value="{{t.value}}">{{localize t.label}}</option>
+      {{/each}} {{/if}} {{#if (eq attr.modtype "Vehicle Stat") }} {{#each ../this.FFG.vehicle_stats as |t|}}
       <option value="{{t.value}}">{{localize t.label}}</option>
       {{/each}} {{/if}} {{/select}}
     </select>


### PR DESCRIPTION
Fix item modifier for 'all' type where it was not looking for the type in the right location. 
Fix item modifier for 'vehicle' type by adding new checks.
Add internationalization of 'Vehicle Stats'. Used online translator.
https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1223