### PR TITLE
Mods on attachments 1191

### DIFF
--- a/modules/helpers/embeddeditem-helpers.js
+++ b/modules/helpers/embeddeditem-helpers.js
@@ -235,9 +235,9 @@ export default class EmbeddedItemHelpers {
       // this is a modifier on an attachment
       ownedItem.system.itemattachment.forEach((a, index) => {
         if (!isNaN(modifierId)) {
-          modifierIndex = modifierId - ownedItem.system[modifierType].length;
+          modifierIndex = modifierId;
         } else {
-          modifierIndex = a.system[modifierType].findIndex((m) => m.id === parseInt(modifierId, 10) - ownedItem.system[modifierType].length);
+          modifierIndex = a.system[modifierType].findIndex((m) => m.id === parseInt(modifierId, 10));
         }
         if (modifierIndex > -1) {
           item = a.system[modifierType][modifierIndex];

--- a/modules/helpers/embeddeditem-helpers.js
+++ b/modules/helpers/embeddeditem-helpers.js
@@ -88,11 +88,20 @@ export default class EmbeddedItemHelpers {
     CONFIG.logger.debug("Starting dataPointer", dataPointer);
     parents.forEach((flags) => {
       if (flags.ffgTempItemType && flags.ffgTempItemIndex) {
-        CONFIG.logger.debug(`Traversing ${flags.ffgTempItemType} into ${flags.ffgTempItemIndex}`);
+        CONFIG.logger.debug(`Traversing into ${flags.ffgTempItemType} #${flags.ffgTempItemIndex}`);
         dataPointer = dataPointer.system[flags.ffgTempItemType][flags.ffgTempItemIndex];
       }
     });
     CONFIG.logger.debug("Final dataPointer", dataPointer);
+    await mergeObject(
+        temporaryItem,
+        ItemHelpers.normalizeDataStructure(data),
+        {
+          recursive: true,
+          insertKeys: true,
+          insertValues: true,
+        },
+    );
 
     mergeObject(dataPointer, {...temporaryItem, ...ItemHelpers.normalizeDataStructure(data)});
     mergeObject(dataPointer.flags, temporaryItem.flags);

--- a/modules/helpers/item-helpers.js
+++ b/modules/helpers/item-helpers.js
@@ -48,28 +48,35 @@ export default class ItemHelpers {
       // v10 items are no longer created in the global scope if they exist only on an actor (or another item)
       if (this.object.flags.starwarsffg.ffgParent.starwarsffg.ffgTempId) {
         let parent_object = await game.items.get(this.object.flags.starwarsffg.ffgParent.starwarsffg.ffgTempId);
+        let tempIndex = this.object.flags.starwarsffg?.ffgTempItemIndex;
+        if (tempIndex) {
+          // TODO: the below code should not be in an else block (or at least not a single one)
+          mergeObject(parent_object.system.itemattachment[tempIndex], ItemHelpers.normalizeDataStructure(formData), {insertKeys: true});
+          await parent_object.update({'system': {'itemattachment': parent_object.system.itemattachment}});
+        } else {
 
-        // search for the relevant attachment
-        let updated_items = [];
-        parent_object.system.itemattachment.forEach(function (i) {
-          if (i._id === updated_id) {
+          // search for the relevant attachment
+          let updated_items = [];
+          parent_object.system.itemattachment.forEach(function (i) {
+            if (i._id === updated_id) {
               // this is the item we want to update, replace it
               i = formData;
-          }
-          updated_items.push(i)
-        });
-        await parent_object.update({'system': {'itemattachment': updated_items}});
+            }
+            updated_items.push(i)
+          });
+          await parent_object.update({'system': {'itemattachment': updated_items}});
 
-        // search for the relevant quality
-        updated_items = [];
-        parent_object.system.itemmodifier.forEach(function (i) {
-          if (i._id === updated_id) {
+          // search for the relevant quality
+          updated_items = [];
+          parent_object.system.itemmodifier.forEach(function (i) {
+            if (i._id === updated_id) {
               // this is the item we want to update, replace it
               i = formData;
-          }
-          updated_items.push(i)
-        });
-        await parent_object.update({'system': {'itemmodifier': updated_items}});
+            }
+            updated_items.push(i)
+          });
+          await parent_object.update({'system': {'itemmodifier': updated_items}});
+        }
 
       }
     } catch (error) {
@@ -118,5 +125,16 @@ export default class ItemHelpers {
         }
       }
     }
+  }
+
+  /**
+   * Takes formData and move anything under .data into .system in preparation for an item.update() call
+   * @param formData
+   * @returns {*}
+   */
+  static normalizeDataStructure(formData) {
+    formData.system = formData?.data;
+    delete formData.data;
+    return formData;
   }
 }

--- a/modules/helpers/item-helpers.js
+++ b/modules/helpers/item-helpers.js
@@ -94,7 +94,14 @@ export default class ItemHelpers {
   static normalizeDataStructure(formData) {
     const updatedData = foundry.utils.deepClone(formData);
     if (Object.keys(formData).includes('data')) {
-      updatedData.system = updatedData?.data;
+      if (!Object.keys(formData).includes('system')) {
+        // sometimes we get formData with a mix of data and system...
+        updatedData.system = {};
+      }
+      updatedData.system = foundry.utils.mergeObject(
+          updatedData.system,
+          updatedData.data
+      );
       delete updatedData.data;
     }
     return updatedData;

--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -57,11 +57,6 @@ export class ItemFFG extends ItemBaseFFG {
     const actor = this.actor ? this.actor : {};
     const data = item.system;
 
-    if (!item._id) {
-        // the item is not being done prepared
-        return;
-    }
-
     if (!item.flags.starwarsffg) {
       await item.updateSource({
         flags: {

--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -298,7 +298,7 @@ export class ItemFFG extends ItemBaseFFG {
       default:
     }
 
-    if (["weapon", "armour"].includes(this.type)) {
+    if (["weapon", "armour", "shipweapon"].includes(this.type)) {
       // get all item attachments
       let totalHPUsed = 0;
 

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -60,6 +60,7 @@ export class ItemSheetFFG extends ItemSheet {
     data.data = data.item.system;
 
     if (options?.action === "update" && this.object.compendium) {
+      delete options.data._id;
       data.item = mergeObject(data.item, options.data);
     } else if (options?.action === "ffgUpdate") {
       if (options?.data?.data) {

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -59,10 +59,12 @@ export class ItemSheetFFG extends ItemSheet {
 
     data.data = data.item.system;
 
+
     if (options?.action === "update" && this.object.compendium) {
       delete options.data._id;
       data.item = mergeObject(data.item, options.data);
     } else if (options?.action === "ffgUpdate") {
+      delete options?.data?.system?.description;
       if (options?.data?.data) {
         data.data = mergeObject(data.data, options.data.data);
         // we are going to merge options.data into data.item and can't set data.item.data this way
@@ -255,6 +257,9 @@ export class ItemSheetFFG extends ItemSheet {
 
     data.FFG = CONFIG.FFG;
     data.renderedDesc = PopoutEditor.renderDiceImages(data.description, this.actor ? this.actor : {});
+    if (!data.renderedDesc) {
+      data.data.renderedDesc = PopoutEditor.renderDiceImages(data?.item?.system?.description, this.actor ? this.actor : {});
+    }
 
     return data;
   }
@@ -504,6 +509,7 @@ export class ItemSheetFFG extends ItemSheet {
       let itemIndex = li.dataset.itemIndex;
 
       if ($(li).hasClass("adjusted")) {
+        // loads modifiers added by other things, e.g. attachments
         return await EmbeddedItemHelpers.loadItemModifierSheet(this.object.id, itemType, itemIndex, this.object?.actor?.id);
       }
 
@@ -573,12 +579,12 @@ export class ItemSheetFFG extends ItemSheet {
             ffgTempId: this.object.id,                // here, this represents the ID of the item this is on
             ffgTempItemType: itemType,                // modified item type
             ffgTempItemIndex: itemIndex,              // modified item index
-            ffgParent: this.object.flags.starwarsffg, // flags from the parent
+            ffgParent: this.object.flags,             // flags from the parent
             ffgIsTemp: true,                          // this is a temporary item
           }
         };
 
-        await EmbeddedItemHelpers.updateRealObject(this.object, {system: { itemmodifier: [item]}}); // TODO: add this properly
+        await EmbeddedItemHelpers.updateRealObject(item, {system: { active: item.system.active}});
 
       } else {
         let formData = {};

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -916,10 +916,10 @@ export class ItemSheetFFG extends ItemSheet {
           break;
         }
         case "itemattachment": {
-          if (this.object.system.hardpoints.current - itemObject.system.hardpoints.value >= 0) {
+          if (this.object.system.hardpoints.adjusted - itemObject.system.hardpoints.value >= 0) {
             items.push(itemObject);
           } else {
-            ui.notifications.warn(`Item does not have enough available hardpoints (${this.object.system.hardpoints.current} left)`);
+            ui.notifications.warn(`Item does not have enough available hardpoints (${this.object.system.hardpoints.adjusted} left)`);
           }
           break;
         }

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -34,6 +34,28 @@ export class ItemSheetFFG extends ItemSheet {
   /** @override */
   async getData(options) {
     let data = super.getData(options);
+    // this code was mostly written by Phind
+    // removing a key from a dict in Foundry requires submitting it with a new key of `-=key` and a value of null
+    // without explicitly replacing values, we end up duplicating entries instead of removing the one
+    // so instead, we go and manually remove any mods which have been deleted
+
+    // find any deleted attributes
+    const deleted_keys = EmbeddedItemHelpers.findKeysIncludingStringRecursively(
+        data,
+        '-=attr',
+    );
+    // remove matching attributes from the existing object
+    deleted_keys.forEach(function (cur_key) {
+      EmbeddedItemHelpers.removeKeyFromObject(
+        data,
+        cur_key,
+      );
+      EmbeddedItemHelpers.removeKeyFromObject(
+        data,
+        cur_key,
+      );
+    });
+    // this is the end of the de-duplicating -=key stuff
 
     data.data = data.item.system;
 

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -620,7 +620,13 @@ export class ItemSheetFFG extends ItemSheet {
       CONFIG.logger.debug("Adding mod with the following data", tempItem);
 
       this.object.system[itemType].push(tempItem.toJSON());
-      await this.object.update({system: {[itemType]: [tempItem.toJSON()]}}); // TODO: merge instead of overwrite
+      await this.object.update(
+        {
+          system: {
+            [itemType]: this.object.system[itemType],
+          }
+        }
+      );
       this.object.sheet.render(true);
     });
   }

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -42,9 +42,12 @@ export class ItemSheetFFG extends ItemSheet {
     } else if (options?.action === "ffgUpdate") {
       if (options?.data?.data) {
         data.data = mergeObject(data.data, options.data.data);
+        // we are going to merge options.data into data.item and can't set data.item.data this way
+        delete options.data.data;
       } else {
         data.data = mergeObject(data.data, options.data);
       }
+      data.item = mergeObject(data.item, options.data); // some fields are read out of item, some are read out of data
     }
 
     data.classType = this.constructor.name;

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -18,6 +18,8 @@ export class ItemSheetFFG extends ItemSheet {
       classes: ["starwarsffg", "sheet", "item"],
       tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }],
       scrollY: [".sheet-body", ".tab"],
+      action: null,
+      data: null,
     });
   }
 
@@ -39,9 +41,9 @@ export class ItemSheetFFG extends ItemSheet {
       data.item = mergeObject(data.item, options.data);
     } else if (options?.action === "ffgUpdate") {
       if (options?.data?.data) {
-        data.item = mergeObject(data.item, options.data);
+        data.data = mergeObject(data.data, options.data.data);
       } else {
-        data.item.data = mergeObject(data.item.data, options.data);
+        data.data = mergeObject(data.data, options.data);
       }
     }
 
@@ -496,7 +498,7 @@ export class ItemSheetFFG extends ItemSheet {
             ffgTempItemIndex: itemIndex,
             ffgIsTemp: true,
             ffgParent: this.object.flags,
-            //ffgParentApp: this.appId, // TODO: check if this is needed
+            ffgParentApp: this.appId, // TODO: check if this is needed
           }
         },
       };

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -511,8 +511,8 @@ export class ItemSheetFFG extends ItemSheet {
               ffgTempItemType: itemType,
               ffgTempItemIndex: itemIndex,
               ffgIsTemp: true,
-              //ffgUuid: this.object.uuid, // TODO: check if this is needed
-              //ffgIsOwned: this.object.isEmbedded, // TODO: check if this is needed
+              ffgUuid: this.object.uuid, // TODO: check if this is needed (needed when item on actor)
+              ffgIsOwned: this.object.isEmbedded, // TODO: check if this is needed (needed when item on actor)
             }
           },
         };
@@ -537,7 +537,7 @@ export class ItemSheetFFG extends ItemSheet {
       const item = this.object.system[itemType][itemIndex];
       item.system.active = !item.system.active;
 
-      if (this.object.flags.starwarsffg.ffgTempId) {
+      if (this.object.flags.starwarsffg.ffgTempId && this.object.flags.starwarsffg.ffgTempId !== this.object._id) {
         // this is a temporary sheet for an embedded item
 
         item.flags = {
@@ -578,9 +578,9 @@ export class ItemSheetFFG extends ItemSheet {
             ffgTempItemIndex: -1,                       // index of the added item within the parent
             ffgParent: this.object.flags.starwarsffg,   // flags from the parent
             ffgIsTemp: true,                            // this is a temporary item
-            //ffgUuid: this.object.uuid,                  // UUID for the parent (if available) TODO: check if this is needed
+            ffgUuid: this.object.uuid,                  // UUID for the parent (if available) TODO: check if this is needed
             ffgParentApp: this.appId,                   // not sure what this is x.x
-            //ffgIsOwned: this.object.isEmbedded,         // if this is within an actor TODO: check if this is needed
+            ffgIsOwned: this.object.isEmbedded,         // if this is within an actor TODO: check if this is needed
           }
         },
         system: {
@@ -590,9 +590,10 @@ export class ItemSheetFFG extends ItemSheet {
       };
 
       let tempItem = await Item.create(temp, { temporary: true });
+      CONFIG.logger.debug("Adding mod with the following data", tempItem);
 
       this.object.system[itemType].push(tempItem.toJSON());
-      await this.object.update({system: {itemType: [tempItem.toJSON()]}}); // TODO: merge instead of overwrite
+      await this.object.update({system: {[itemType]: [tempItem.toJSON()]}}); // TODO: merge instead of overwrite
       this.object.sheet.render(true);
     });
   }

--- a/modules/items/itembase-ffg.js
+++ b/modules/items/itembase-ffg.js
@@ -10,7 +10,6 @@ export default class ItemBaseFFG extends Item {
       return;
     } else {
       const preState = Object.values(this.apps)[0]._state;
-
       await EmbeddedItemHelpers.updateRealObject(this, data);
 
       if (this.flags?.starwarsffg?.ffgParent?.isCompendium || Object.values(this.apps)[0]._state !== preState) {

--- a/modules/items/itembase-ffg.js
+++ b/modules/items/itembase-ffg.js
@@ -2,7 +2,7 @@ import EmbeddedItemHelpers from "../helpers/embeddeditem-helpers.js";
 
 export default class ItemBaseFFG extends Item {
   async update(data, options = {}) {
-    if ((!this.flags?.starwarsffg?.ffgTempId && this.flags?.starwarsffg?.ffgTempId !== null) || (this.flags?.starwarsffg?.ffgTempId === this._id && this._id !== null && !this.isTemp) || this.flags?.starwarsffg?.ffgIsOwned) {
+    if ((!this.flags?.starwarsffg?.ffgTempId && this.flags?.starwarsffg?.ffgTempId !== null) || (this.flags?.starwarsffg?.ffgTempId === this._id && this._id !== null && !this.isTemp) || (this.flags?.starwarsffg?.ffgIsOwned && !this.flags?.starwarsffg?.ffgIsTemp)) {
       CONFIG.logger.debug("Updating real item", this, data);
       await super.update(data, options);
       // if (this.compendium) {

--- a/modules/items/itembase-ffg.js
+++ b/modules/items/itembase-ffg.js
@@ -11,7 +11,7 @@ export default class ItemBaseFFG extends Item {
       return;
     } else {
       CONFIG.logger.debug("Updating fake item item", this, data);
-      const preState = Object.values(this.apps)[0]._state;
+      const preState = Object.values(this.apps)[0]?._state;
       await EmbeddedItemHelpers.updateRealObject(this, data);
 
       if (this.flags?.starwarsffg?.ffgParent?.isCompendium || Object.values(this.apps)[0]._state !== preState) {

--- a/modules/items/itembase-ffg.js
+++ b/modules/items/itembase-ffg.js
@@ -2,7 +2,7 @@ import EmbeddedItemHelpers from "../helpers/embeddeditem-helpers.js";
 
 export default class ItemBaseFFG extends Item {
   async update(data, options = {}) {
-    if (!this.flags?.starwarsffg?.ffgTempId || (this.flags?.starwarsffg?.ffgTempId === this._id && !this.isTemp) || this.flags?.starwarsffg?.ffgIsOwned) {
+    if ((!this.flags?.starwarsffg?.ffgTempId && this.flags?.starwarsffg?.ffgTempId !== null) || (this.flags?.starwarsffg?.ffgTempId === this._id && this._id !== null && !this.isTemp) || this.flags?.starwarsffg?.ffgIsOwned) {
       CONFIG.logger.debug("Updating real item", this, data);
       await super.update(data, options);
       // if (this.compendium) {

--- a/modules/items/itembase-ffg.js
+++ b/modules/items/itembase-ffg.js
@@ -22,8 +22,8 @@ export default class ItemBaseFFG extends Item {
         let me = this;
 
         // we're working on an embedded item
-        await this.sheet.render(true);
-        const appId = this.system?.flags?.starwarsffg?.ffgParentApp;
+        await this.sheet.render(true, {action: "ffgUpdate", data: data});
+        const appId = this?.flags?.starwarsffg?.ffgParentApp;
         if (appId) {
           const newData = ui.windows[appId].object;
           newData[this.flags.starwarsffg.ffgTempItemType][this.flags.starwarsffg.ffgTempItemIndex] = mergeObject(newData[this.flags.starwarsffg.ffgTempItemType][this.flags.starwarsffg.ffgTempItemIndex], this);

--- a/modules/items/itembase-ffg.js
+++ b/modules/items/itembase-ffg.js
@@ -3,12 +3,14 @@ import EmbeddedItemHelpers from "../helpers/embeddeditem-helpers.js";
 export default class ItemBaseFFG extends Item {
   async update(data, options = {}) {
     if (!this.flags?.starwarsffg?.ffgTempId || (this.flags?.starwarsffg?.ffgTempId === this._id && !this.isTemp) || this.flags?.starwarsffg?.ffgIsOwned) {
+      CONFIG.logger.debug("Updating real item", this, data);
       await super.update(data, options);
       // if (this.compendium) {
       //   return this.sheet.render(true);
       // }
       return;
     } else {
+      CONFIG.logger.debug("Updating fake item item", this, data);
       const preState = Object.values(this.apps)[0]._state;
       await EmbeddedItemHelpers.updateRealObject(this, data);
 

--- a/styles/mandar.css
+++ b/styles/mandar.css
@@ -2868,32 +2868,36 @@ img {
   width: 100%;
 }
 
-.starwarsffg .item-sheet-vehicle-weapon .charname {
+.starwarsffg .item-sheet-vehicle-weapon .characteristic-item {
   width: 100%;
 }
 
-.starwarsffg .item-sheet-vehicle-weapon .charname input {
+.starwarsffg .item-sheet-vehicle-weapon .characteristic-item input {
   color: #1f1c37;
   border: 0;
 }
 
-.starwarsffg .item-sheet-vehicle-weapon .charname input:focus {
+.starwarsffg .item-sheet-vehicle-weapon .characteristic-item input:focus {
   box-shadow: 0 0 5px #7da9c2;
   background-color: #7da9c2;
 }
 
-.starwarsffg .item-sheet-vehicle-weapon .charname .characteristic {
+.starwarsffg .item-sheet-vehicle-weapon .characteristic-item .characteristic {
   border: 5px double #bffebf;
 }
 
-.starwarsffg .item-sheet-vehicle-weapon .charname .characteristic .adjustedvalues-left {
+.starwarsffg .item-sheet-vehicle-weapon .characteristic-item .characteristic .adjustedvalues-left {
   position: absolute;
   top: 0;
-  right: 2px;
-  color: red;
+  right: 0;
+  background: red;
+  color: white;
+  width: 1rem;
+  border-radius: 0 0.5rem;
+  border: 1px solid transparent;
 }
 
-.starwarsffg .item-sheet-vehicle-weapon .charname .characteristic .adjustedvalues-left.positive {
+.starwarsffg .item-sheet-vehicle-weapon .characteristic-item .characteristic .adjustedvalues-left.positive {
   color: green;
 }
 

--- a/templates/items/ffg-itemattachment-sheet.html
+++ b/templates/items/ffg-itemattachment-sheet.html
@@ -75,11 +75,11 @@
             <td>{{item.name}}</td>
             <!-- <td data-item-name="itemmodifier" data-item-index="{{id}}">
               <div class="quantity increase"><i class="far fa-plus-square"></i></div>
-              {{item.data.rank}}
+              {{item.system.rank}}
               <div class="quantity decrease"><i class="far fa-minus-square"></i></div>
             </td> -->
             <td data-item-name="itemmodifier" data-item-index="{{id}}">
-              <div class="modifier-active"><i class="far {{#if item.data.active}} fa-check-square {{else}} fa-square {{/if}}"></i></div>
+              <div class="modifier-active"><i class="far {{#if item.system.active}} fa-check-square {{else}} fa-square {{/if}}"></i></div>
             </td>
             <td class="add-modifier" data-item-name="itemmodifier" data-item-index="{{id}}"><i class="fas fa-edit"></i><i class="fas fa-times item-delete"></i></td>
           </tr>

--- a/templates/parts/shared/ffg-block.html
+++ b/templates/parts/shared/ffg-block.html
@@ -10,7 +10,7 @@
         {{#if (eq blocktype "pills")}}
         <ul class="item-pill-list">
           {{#each fields as |item id|}}
-          <li class="item-pill {{#if adjusted}}adjusted{{/if}}" data-item-name="{{../name}}" data-item-index="{{id}}">
+            <li class="item-pill {{#if adjusted}}adjusted{{/if}}" data-item-name="{{../name}}" data-item-index="{{#if adjusted}}{{item.flags.starwarsffg.ffgTempItemIndex}}{{else}}{{id}}{{/if}}">
             {{item.name}} {{#if item.system.rank}}
             <i class="rank">{{item.system.rank}}</i>
             {{/if}} {{#if adjusted}}{{else}}<i class="fas fa-times item-delete"></i>{{/if}}


### PR DESCRIPTION
Fixes item mods (which have been broken since Foundry `0.8.x`.) You can now add them, remove them, activate them, and edit them. This also removes further legacy `data.data` calls I've somehow missed...