### PR TITLE
fix(attachments): correctly display qualities from attachments

### DIFF
--- a/templates/parts/shared/ffg-block.html
+++ b/templates/parts/shared/ffg-block.html
@@ -11,9 +11,15 @@
         <ul class="item-pill-list">
           {{#each fields as |item id|}}
             <li class="item-pill {{#if adjusted}}adjusted{{/if}}" data-item-name="{{../name}}" data-item-index="{{#if adjusted}}{{item.flags.starwarsffg.ffgTempItemIndex}}{{else}}{{id}}{{/if}}">
-            {{item.name}} {{#if item.system.rank}}
-            <i class="rank">{{item.system.rank}}</i>
-            {{/if}} {{#if adjusted}}{{else}}<i class="fas fa-times item-delete"></i>{{/if}}
+            {{item.name}}
+            {{#if item.system.rank_current}}
+              <i class="rank">{{item.system.rank_current}}</i>
+            {{else}}
+              {{#if item.system.rank}}
+              <i class="rank">{{item.system.rank}}</i>
+              {{/if}}
+            {{/if}}
+            {{#if adjusted}}{{else}}<i class="fas fa-times item-delete"></i>{{/if}}
           </li>
           {{/each}}
         </ul>


### PR DESCRIPTION
* now properly displays the ranks of a quality from multiple, identical mods on an attachment

#1307