### PR TITLE
fix(mods): permits removing mod rank

### DIFF
--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -159,10 +159,16 @@ export class ItemFFG extends ItemBaseFFG {
                 const foundItem = data.adjusteditemmodifier.find((i) => i.name === am.name);
 
                 if (foundItem) {
-                  foundItem.system.rank_current = parseInt(foundItem.system.rank_current, 10) + 1;
+                  if (foundItem.system?.rank) {
+                    foundItem.system.rank_current = parseInt(foundItem.system.rank_current, 10) + 1;
+                  }
                 } else {
-                  am.system.rank_current = 1;
-                  data.adjusteditemmodifier.push({ ...am, adjusted: true });
+                  if (am.system?.rank) {
+                    am.system.rank_current = 1;
+                  } else {
+                    am.system.rank_current = null;
+                  }
+                  data.adjusteditemmodifier.push({...am, adjusted: true});
                 }
               });
             }
@@ -241,10 +247,16 @@ export class ItemFFG extends ItemBaseFFG {
                 const foundItem = data.adjusteditemmodifier.find((i) => i.name === am.name);
 
                 if (foundItem) {
-                  foundItem.system.rank_current = parseInt(foundItem.system.rank_current, 10) + 1;
+                  if (foundItem.system?.rank) {
+                    foundItem.system.rank_current = parseInt(foundItem.system.rank_current, 10) + 1;
+                  }
                 } else {
-                  am.system.rank_current = 1;
-                  data.adjusteditemmodifier.push({ ...am, adjusted: true });
+                  if (am.system?.rank) {
+                    am.system.rank_current = 1;
+                  } else {
+                    am.system.rank_current = null;
+                  }
+                  data.adjusteditemmodifier.push({...am, adjusted: true});
                 }
               });
             }

--- a/templates/items/ffg-itemmodifier-sheet.html
+++ b/templates/items/ffg-itemmodifier-sheet.html
@@ -8,15 +8,12 @@
         <div class="container flex-group-center item-name">
           <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name" /></h1>
         </div>
-
-        <div class="hidden-content">
-          <input name="data.rank" type="text" value="{{data.rank}}" />
-        </div>
       </div>
     </div>
+
   </header>
 
-  {{!-- Sheet Tab Navigation --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-tabs.html" displayLimited=true limited=limited items=(array (object tab="description" label="SWFFG.TabDescription" icon="far fa-file-alt" cls=classType) (object tab="attributes" label="SWFFG.TabModifiers" icon="fas fa-cog" cls=classType) (object tab="configuration" label="SWFFG.TabConfiguration" icon="fas fa-cog" isHidden=isTemp cls=classType) )}} {{!-- Sheet Body --}}
+  {{!-- Sheet Tab Navigation --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-tabs.html" displayLimited=true limited=limited items=(array (object tab="description" label="SWFFG.TabDescription" icon="far fa-file-alt" cls=classType) (object tab="attributes" label="SWFFG.TabModifiers" icon="fas fa-cog" cls=classType) (object tab="configuration" label="SWFFG.TabConfiguration" icon="fas fa-cog" cls=classType) )}} {{!-- Sheet Body --}}
   <section class="sheet-body small">
     {{!-- Description Tab --}}
     <div class="tab" data-group="primary" data-tab="description">
@@ -30,7 +27,10 @@
 
     <div class="tab configuration" data-group="primary" data-tab="configuration">
       <div class="container flex-group-center">
-        {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.Type" type="Dropdown" name="data.type" value=data.type options=this.FFG.itemmodifier_types)}}
+        {{#if isTemp }}{{ else }}
+          {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.Type" type="Dropdown" name="data.type" value=data.type options=this.FFG.itemmodifier_types)}}
+        {{/if}}
+        {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="Rank" type="Number" name="data.rank" value=data.rank )}}
       </div>
     </div>
   </section>


### PR DESCRIPTION
* itemmodifier ranks are now displayed to the user
* these ranks can be set to null. if set to null, the quality is shown as unranked
* ranks are still treated as only 1 from each added mod on an attachment

#899