### PR TITLE
fix(combat): look up claims properly

### DIFF
--- a/modules/combat-ffg.js
+++ b/modules/combat-ffg.js
@@ -216,7 +216,11 @@ export class CombatFFG extends Combat {
    * @returns {*|*[]} - a list of combatant IDs (NOT token IDs, NOT actor IDs)
    */
   getClaims(round) {
-    return this.getFlag('starwarsffg', 'combatClaims')[round] || [];
+    const combatClaims = this.getFlag('starwarsffg', 'combatClaims');
+    if (combatClaims) {
+      return combatClaims[round] || [];
+    }
+    return [];
   }
 
   /**


### PR DESCRIPTION
* fixes a bug where new combats don't have flags, resulting in a blank tracker

classic, am I right? :p