### PR TITLE
feat(chat): update quality links

### DIFF
--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -491,7 +491,7 @@ export class ItemFFG extends ItemBaseFFG {
     // General equipment properties
     else if (this.type !== "talent") {
       if (data.hasOwnProperty("adjusteditemmodifier")) {
-        const qualities = data.adjusteditemmodifier?.map((m) => `<li class='item-pill ${m.adjusted ? "adjusted hover" : ""}' data-item-id='${this.id}' data-uuid='${this.uuid}' data-modifier-id='${m._id}' data-modifier-type='${m.type}'>${m.name} ${m.system?.rank_current > 0 ? m.system.rank_current : ""} ${m.adjusted ? "<div class='tooltip2'>" + game.i18n.localize("SWFFG.FromAttachment") + "</div>" : ""}</li>`);
+        const qualities = data.adjusteditemmodifier?.map((m) => `<li class='item-pill ${m.adjusted ? "adjusted hover" : ""}' data-item-embed-type='itemmodifier' data-item-embed-name='${m.name}' data-item-embed-img='${m.img}' data-item-embed-description='${m.system.description}' data-item-embed-modifiers='${JSON.stringify(m.system.attributes)}' data-item-embed-rank='${m.system.rank_current}' data-item-embed='true'>${m.name} ${m.system?.rank_current > 0 ? m.system.rank_current : ""} ${m.adjusted ? "<div class='tooltip2'>" + game.i18n.localize("SWFFG.FromAttachment") + "</div>" : ""}</li>`);
 
         props.push(`<div>${game.i18n.localize("SWFFG.ItemDescriptors")}: <ul>${qualities.join("")}<ul></div>`);
       }

--- a/modules/swffg-main.js
+++ b/modules/swffg-main.js
@@ -517,20 +517,41 @@ Hooks.on("renderChatMessage", (app, html, messageData) => {
   html.find(".item-display .item-pill, .item-properties .item-pill").on("click", async (event) => {
     event.preventDefault();
     event.stopPropagation();
-    const li = event.currentTarget;
-    let uuid = li.dataset.itemId;
-    let modifierId = li.dataset.modifierId;
-    let modifierType = li.dataset.modifierType;
+    const li = $(event.currentTarget);
+    const itemType = li.attr("data-item-embed-type");
+    let itemData = {};
+    const newEmbed = li.attr("data-item-embed");
 
-    if (li.dataset.uuid) {
-      uuid = li.dataset.uuid;
+    if (newEmbed === "true" && itemType === "itemmodifier") {
+      itemData = {
+        img: li.attr('data-item-embed-img'),
+        name: li.attr('data-item-embed-name'),
+        type: li.attr('data-item-embed-type'),
+        system: {
+          description: li.attr('data-item-embed-description'),
+          attributes: JSON.parse(li.attr('data-item-embed-modifiers')),
+          rank: li.attr('data-item-embed-rank'),
+          rank_current: li.attr('data-item-embed-rank'),
+        },
+      };
+      const tempItem = await Item.create(itemData, {temporary: true});
+      tempItem.sheet.render(true);
+    } else {
+      CONFIG.logger.debug(`Unknown item type: ${itemType}, or lacking new embed system`);
+      const li2 = event.currentTarget;
+      let uuid = li2.dataset.itemId;
+      let modifierId = li2.dataset.modifierId;
+      let modifierType = li2.dataset.modifierType;
+      if (li2.dataset.uuid) {
+        uuid = li2.dataset.uuid;
+      }
+
+      const parts = uuid.split(".");
+
+      const [entityName, entityId, embeddedName, embeddedId] = parts;
+
+      await EmbeddedItemHelpers.displayOwnedItemItemModifiersAsJournal(embeddedId, modifierType, modifierId, entityId);
     }
-
-    const parts = uuid.split(".");
-
-    const [entityName, entityId, embeddedName, embeddedId] = parts;
-
-    await EmbeddedItemHelpers.displayOwnedItemItemModifiersAsJournal(embeddedId, modifierType, modifierId, entityId);
   });
 });
 

--- a/templates/chat/roll-weapon-card.html
+++ b/templates/chat/roll-weapon-card.html
@@ -14,7 +14,9 @@
   <div class="specials">
     <h5>
       {{#each data.system.adjusteditemmodifier as |item id|}}
-      <li class="item-pill" data-item-id="{{../data.flags.starwarsffg.ffgUuid}}" data-modifier-id="{{item._id}}"  data-uuid="{{ ../data.flags.starwarsffg.uuid }}" data-modifier-type="{{item.type}}">{{item.name}} {{#if (gt item.system.rank_current 0)}}{{item.system.rank_current}}{{else}}{{/if}}</li>
+      <li class="item-pill" data-item-embed-type="{{item.type}}" data-item-embed-name="{{item.name}}" data-item-embed-img="{{item.img}}" data-item-embed-description="{{item.system.description}}" data-item-embed-modifiers="{{json item.system.attributes}}" data-item-embed-rank="{{item.system.rank_current}}" data-item-embed="true">
+        {{item.name}} {{#if (gt item.system.rank_current 0)}}{{item.system.rank_current}}{{else}}{{/if}}
+      </li>
       {{/each}}
     </h5>
   </div>


### PR DESCRIPTION
* now embeds item quality data in chat messages instead of linking to it
* this means that previous messages will always properly link to the item at tht time of sending messages, even if items are deleted or users don't have permission to view them
* existing messages will use existing logic

#1336