### PR TITLE
feat(species): allow species to have talents

### DIFF
--- a/modules/importer/import-helpers.js
+++ b/modules/importer/import-helpers.js
@@ -167,7 +167,14 @@ export default class ImportHelpers {
    * @param  {string} id - Entity Id
    * @returns {object} - Entity Object Data
    */
-  static async findCompendiumEntityByImportId(type, id, packId, itemType) {
+  static async findCompendiumEntityByImportId(type, id, packId, itemType, skipCache) {
+    if (skipCache) {
+      const pack = game.packs.get(packId);
+      const contents = await pack.getDocuments();
+      return contents.find((item) => {
+        return item.flags.starwarsffg.ffgimportid === id;
+      });
+    }
     const cachePack = async (packid) => {
       if (!CONFIG.temporary[packid]) {
         const pack = await game.packs.get(packid);
@@ -2252,9 +2259,25 @@ export default class ImportHelpers {
 
         if (updateData?.data?.attributes) {
           // Remove and repopulate all modifiers
-          if (entry.data?.attributes) {
-            for (let k of Object.keys(entry.data.attributes)) {
+          if (entry.system?.attributes) {
+            for (let k of Object.keys(entry.system.attributes)) {
               if (!updateData.data.attributes.hasOwnProperty(k)) updateData.data.attributes[`-=${k}`] = null;
+            }
+          }
+        }
+        if (updateData?.data?.specializations) {
+          // Remove and repopulate all specializations
+          if (entry.system?.specializations) {
+            for (let k of Object.keys(entry.system.specializations)) {
+              if (!updateData.data.specializations.hasOwnProperty(k)) updateData.data.specializations[`-=${k}`] = null;
+            }
+          }
+        }
+        if (updateData?.data?.talents) {
+          // Remove and repopulate all talents
+          if (entry.system?.talents) {
+            for (let k of Object.keys(entry.system.talents)) {
+              if (!updateData.data.talents.hasOwnProperty(k)) updateData.data.talents[`-=${k}`] = null;
             }
           }
         }

--- a/modules/importer/oggdude/importers/species.js
+++ b/modules/importer/oggdude/importers/species.js
@@ -26,6 +26,7 @@ export default class Species {
             data.data = {
               attributes: {},
               description: item.Description,
+              talents: {},
             };
 
             // populate starting characteristics
@@ -77,6 +78,22 @@ export default class Species {
                   };
                 }
               });
+            }
+
+            // populate talents
+            if (item?.TalentModifiers?.TalentModifier) {
+              for (const talentData of Object.values(item.TalentModifiers)) {
+                const talentKey = talentData.Key;
+                let talent = await ImportHelpers.findCompendiumEntityByImportId("Item", talentKey, "world.oggdudetalents", "talent", true);
+                if (!talent) {
+                  continue;
+                }
+                data.data.talents[talent._id] = {
+                  name: talent.name,
+                  source: talent.uuid,
+                  id: talent._id,
+                }
+              }
             }
 
             if (item?.OptionChoices?.OptionChoice) {

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -457,7 +457,7 @@ export class ItemSheetFFG extends ItemSheet {
         new Item(item).sheet.render(true);
       });
     } else if (this.object.type === "species") {
-      //try {
+      try {
         const dragDrop = new DragDrop({
           dragSelector: ".item",
           dropSelector: ".tab.talents",
@@ -487,9 +487,9 @@ export class ItemSheetFFG extends ItemSheet {
           let item = await fromUuid(this.object.system.talents[itemId].source);
           new Item(item).sheet.render(true);
         });
-      //} catch (err) {
-      //  CONFIG.logger.debug(err);
-      //}
+      } catch (err) {
+        CONFIG.logger.debug(err);
+      }
     }
 
     // hidden here instead of css to prevent non-editable display of edit button

--- a/modules/swffg-main.js
+++ b/modules/swffg-main.js
@@ -895,6 +895,45 @@ Hooks.once("ready", async () => {
     Hooks.call(`closeAssociatedTalent_${item.object._id}`, item);
   });
 
+  Hooks.on("createItem", (item, options, userId) => {
+    // add talents from species to character
+    if (item.isEmbedded && item.parent.documentName === "Actor") {
+      const actor = item.actor
+      if (item.type === "species" && actor.type === "character") {
+        const toAdd = [];
+        for(const talentId of Object.keys(item.system.talents)) {
+          const talentUuid = item.system.talents[talentId].source;
+          const talent = fromUuidSync(talentUuid);
+          if (talent) {
+            toAdd.push(talent);
+          }
+        }
+        if (toAdd.length > 0) {
+          actor.createEmbeddedDocuments("Item", toAdd);
+        }
+      }
+    }
+  });
+  Hooks.on("deleteItem", (item, options, userId) => {
+    // remove talents added by species
+    if (item.isEmbedded && item.parent.documentName === "Actor") {
+      const actor = item.actor
+      if (item.type === "species" && actor.type === "character") {
+        const toDelete = [];
+        for(const talentId of Object.keys(item.system.talents)) {
+          const speciesTalent = item.system.talents[talentId];
+          const actorTalent = actor.items.find(i => i.name === speciesTalent.name && i.type === "talent");
+          if (actorTalent) {
+            toDelete.push(actorTalent.id);
+          }
+        }
+        if (toDelete.length > 0) {
+          actor.deleteEmbeddedDocuments("Item", toDelete);
+        }
+      }
+    }
+  });
+
   // Display Destiny Pool
   let destinyPool = { light: game.settings.get("starwarsffg", "dPoolLight"), dark: game.settings.get("starwarsffg", "dPoolDark") };
 

--- a/styles/mandar.css
+++ b/styles/mandar.css
@@ -4032,7 +4032,7 @@ img {
   max-width: 24px;
   max-height: 24px;
 }
-.starwarsffg.sheet.item .item-sheet-career .signatureability-pill.item-pill2, .starwarsffg.sheet.item .item-sheet-career .specialization-pill.item-pill2 {
+.starwarsffg.sheet.item .item-sheet-career .signatureability-pill.item-pill2, .starwarsffg.sheet.item .item-sheet-career .specialization-pill.item-pill2, .starwarsffg.sheet.item .item-sheet-species .talent-pill.item-pill2 {
   padding: 0.1rem 0.5rem;
   background-color: rgba(255, 255, 255, 0.25);
   border: 1px solid rgba(255, 255, 255, 0.5);
@@ -4041,7 +4041,7 @@ img {
   width: fit-content;
 }
 
-.starwarsffg.sheet.item .item-sheet-career .signatureability-pill.item-pill2 .item-delete, .starwarsffg.sheet.item .item-sheet-career .specialization-pill.item-pill2 .item-delete {
+.starwarsffg.sheet.item .item-sheet-career .signatureability-pill.item-pill2 .item-delete, .starwarsffg.sheet.item .item-sheet-career .specialization-pill.item-pill2 .item-delete, .starwarsffg.sheet.item .item-sheet-species .talent-pill.item-pill2 .item-delete {
   cursor: pointer;
 }
 

--- a/template.json
+++ b/template.json
@@ -719,7 +719,8 @@
       "label": "Ship Attachment"
     },
     "species": {
-      "templates": ["core"]
+      "templates": ["core"],
+      "talents": {}
     },
     "criticalinjury": {
       "templates": ["core"],

--- a/templates/items/ffg-species-sheet.html
+++ b/templates/items/ffg-species-sheet.html
@@ -43,7 +43,7 @@
     </div>
   </header>
 
-  {{!-- Sheet Tab Navigation --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-tabs.html" displayLimited=true limited=limited items=(array (object tab="description" label="SWFFG.TabDescription" icon="far fa-file-alt" cls=classType) (object tab="attributes" label="SWFFG.TabModifiers" icon="fas fa-cog" cls=classType) )}} {{!-- Sheet Body --}}
+  {{!-- Sheet Tab Navigation --}} {{> "systems/starwarsffg/templates/parts/shared/ffg-tabs.html" displayLimited=true limited=limited items=(array (object tab="description" label="SWFFG.TabDescription" icon="far fa-file-alt" cls=classType) (object tab="attributes" label="SWFFG.TabModifiers" icon="fas fa-cog" cls=classType) (object tab="talents" label="SWFFG.TabTalents" icon="fas fa-cog" cls=classType))}} {{!-- Sheet Body --}}
   <section class="sheet-body small species">
     {{!-- Description Tab --}}
     <div class="tab" data-group="primary" data-tab="description">
@@ -53,6 +53,15 @@
     {{!-- Modifiers Tab --}}
     <div class="tab attributes" data-group="primary" data-tab="attributes">
       {{> "systems/starwarsffg/templates/parts/shared/ffg-modifiers.html"}}
+    </div>
+
+    {{!-- Talents Tab --}}
+    <div class="tab talents" data-group="primary" data-tab="talents">
+      {{#each data.talents as |talent id|}}
+        <div class="talent-pill item-pill2" data-item-type="talent" data-talent-id="{{id}}">{{talent.name}}
+          <i class="fas fa-times item-delete" data-item-type="talent" data-talent-id="{{id}}"></i>
+        </div>
+      {{/each}}
     </div>
   </section>
 </form>


### PR DESCRIPTION
* allows species to have talents
* when a character gains a species with talents, those talents are added to the character
* when a character loses a species with talents, those talents are removed from the character
* updates the importer to pull in species talents by default
* fixes a bug with career importing wherein specializations would duplicate each time the importer was run
* fixes a bug where attributes were not properly updated on multiple importer runs

#1171