### PR TITLE
fix(sheets): minion skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   * Corrected tooltip for equipped/unequipped gear (and localized it)
   * non-character actors no longer show the option to buy skill ranks
   * Players can no longer purchase Signature Abilities or Force Powers if they do not have enough XP for them
+  * Minion sheets now show "group skill" instead of "career skill"
 
 `1.809`
 * Features: 

--- a/lang/en.json
+++ b/lang/en.json
@@ -71,6 +71,8 @@
   "SWFFG.SkillsName": "Name",
   "SWFFG.SkillsCS": "CS",
   "SWFFG.SkillsCareerSkill": "Career Skill",
+  "SWFFG.SkillsGS": "GS",
+  "SWFFG.SkillsGroupSkill": "Group Skill",
   "SWFFG.SkillsRank": "Rank",
   "SWFFG.SkillsRoll": "Roll",
   "SWFFG.ItemsWeapons": "Weapons",

--- a/templates/parts/actor/ffg-skills.html
+++ b/templates/parts/actor/ffg-skills.html
@@ -7,8 +7,15 @@
         <div class="pure-g skillsHeader">
           <div class="pure-u-12-24">{{skill.label}}</div>
           <div class="pure-u-3-24 hover">
-            {{localize "SWFFG.SkillsCS"}}
-            <div class="tooltip">{{localize "SWFFG.SkillsCareerSkill"}}</div>
+            {{#if (eq ../../this.document.type "minion")}}
+              <span data-tooltip="{{localize 'SWFFG.SkillsGroupSkill'}}" data-tooltip-direction="DOWN">
+                {{localize "SWFFG.SkillsGS"}}
+              </span>
+            {{else}}
+              <span data-tooltip="{{localize 'SWFFG.SkillsCareerSkill'}}" data-tooltip-direction="DOWN">
+                {{localize "SWFFG.SkillsCS"}}
+              </span>
+            {{/if}}
           </div>
           <div class="pure-u-3-24">{{localize "SWFFG.SkillsRank"}}</div>
           <div class="pure-u-6-24">{{localize "SWFFG.SkillsRoll"}}</div>


### PR DESCRIPTION
* update minion skill groups to say "group skill" instead of "career skill"

#1470