### PR TITLE
fix(item): signature ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   * Corrected a bug in the combat tracker where actors claiming a slot not originally belonging to them resulted in both the original slot owner and claiming actor being shown as having acted in the actor summary
   * The buy talent button on specializations no longer disappears when buying >1 talent at a time
   * Corrected a bug in the combat tracker where actors claiming a slot not originally belonging to them prevented them from being removed from combat
+  * Correct default Signature ability height so the bottom isn't ever-so-slightly cut off
 
 `1.809`
 * Features: 

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -278,7 +278,7 @@ export class ItemSheetFFG extends ItemSheet {
         break;
       case "signatureability": {
         this.position.width = 720;
-        this.position.height = 515;
+        this.position.height = 545;
         data.data.isReadOnly = false;
         if (!this.options.editable) {
           data.data.isEditing = false;


### PR DESCRIPTION
* fix default Signature ability height so the bottom isn't ever-so-slightly cut off

#1456