### PR TITLE
feat(actor): move obligation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   * Abilities created during the SWA import process are now created as "Ability" items instead of populating in the biography section
   * Species can now include abilities (and are now included on import)
   * Players can now buy levels in characteristics by clicking the characteristic name
+  * Moved XP amounts to XP log tab
+  * Moved morality/duty/conflict/obligation to a dedicated tab
 * Fixes:
   * Sending a signature ability to chat now includes purchased upgrades
   * Granting XP to the entire group now updates the XP logs
@@ -35,6 +37,7 @@
   * Fixed a bug where attempting to view a talent on a specialization tree did not open anything
   * Allow purchasing skills at the bottom of the skill list by adding a dedicated purchase button
   * The "talent" tab on species items now uses the talent icon
+  * The XP log no longer shows an edit button, as it is currently read only
   * Importer fixes:
     * Career data is now properly set when the OggDude importer is run
     * Re-running the importer no longer duplicates weapons on vehicles

--- a/templates/actors/ffg-character-sheet.html
+++ b/templates/actors/ffg-character-sheet.html
@@ -180,24 +180,7 @@
         {{!-- Experience Box --}}
 
         <div class="grid bio-grid">
-          {{!-- Experience Box --}}
-            {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="split" title="SWFFG.DescriptionXP" fields=(array (object name="data.experience.available" value=data.experience.available type="Number" label="SWFFG.DescriptionXPAvailable") (object name="data.experience.total" value=data.experience.total type="Number" label="SWFFG.DescriptionXPTotal") ))}}
-          {{!-- Obligation Box --}}
-            {{#if (or (eq actor.flags.starwarsffg.config.enableObligation undefined) (eq actor.flags.starwarsffg.config.enableObligation true) )}}
-              {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionObligation" headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'" type="Number" name="data.obligation.value" value=data.obligation.value )}}
-            {{/if}}
-          {{!-- Duty Box --}}
-            {{#if (or (eq actor.flags.starwarsffg.config.enableDuty undefined) (eq actor.flags.starwarsffg.config.enableDuty true) )}}
-              {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionDuty" type="Number" name="data.duty.value" value=data.duty.value headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'")}}
-            {{/if}}
-          {{!-- Morality Box --}}
-            {{#if (or (eq actor.flags.starwarsffg.config.enableMorality undefined) (eq actor.flags.starwarsffg.config.enableMorality true) )}}
-              {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionMorality" type="Number" name="data.morality.value" value=data.morality.value headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'" )}}
-            {{/if}}
-          {{!-- Conflict Box --}}
-            {{#if (or (eq actor.flags.starwarsffg.config.enableConflict undefined) (eq actor.flags.starwarsffg.config.enableConflict true) )}}
-              {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionConflict" type="Number" name="data.conflict.value" value=data.conflict.value headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'" )}}
-            {{/if}}
+
         </div>
       </div>
     </div>
@@ -267,10 +250,29 @@
     </div>
 
     <div class="tab xp" data-group="primary" data-tab="xp">
-      {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.Actors.Sheets.Purchase.LogTitle" type="PopoutEditor" value=xpLog)}}
+      {{!-- Experience Box --}}
+        {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="split" title="SWFFG.DescriptionXP" fields=(array (object name="data.experience.available" value=data.experience.available type="Number" label="SWFFG.DescriptionXPAvailable") (object name="data.experience.total" value=data.experience.total type="Number" label="SWFFG.DescriptionXPTotal") ))}}
+      {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.Actors.Sheets.Purchase.LogTitle" type="PopoutEditor" value=xpLog readonly=true)}}
     </div>
 
     <div class="tab obligation" data-group="primary" data-tab="obligation">
+      {{!-- Obligation Tab --}}
+      {{!-- Obligation Box --}}
+        {{#if (or (eq actor.flags.starwarsffg.config.enableObligation undefined) (eq actor.flags.starwarsffg.config.enableObligation true) )}}
+          {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionObligation" headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'" type="Number" name="data.obligation.value" value=data.obligation.value )}}
+        {{/if}}
+      {{!-- Duty Box --}}
+        {{#if (or (eq actor.flags.starwarsffg.config.enableDuty undefined) (eq actor.flags.starwarsffg.config.enableDuty true) )}}
+          {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionDuty" type="Number" name="data.duty.value" value=data.duty.value headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'")}}
+        {{/if}}
+      {{!-- Morality Box --}}
+        {{#if (or (eq actor.flags.starwarsffg.config.enableMorality undefined) (eq actor.flags.starwarsffg.config.enableMorality true) )}}
+          {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionMorality" type="Number" name="data.morality.value" value=data.morality.value headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'" )}}
+        {{/if}}
+      {{!-- Conflict Box --}}
+        {{#if (or (eq actor.flags.starwarsffg.config.enableConflict undefined) (eq actor.flags.starwarsffg.config.enableConflict true) )}}
+          {{> "systems/starwarsffg/templates/parts/shared/ffg-block.html" (object blocktype="single" title="SWFFG.DescriptionConflict" type="Number" name="data.conflict.value" value=data.conflict.value headerlink=true headerclass="alt-tab" headerattributes="data-tab='obligation'" )}}
+        {{/if}}
       {{#if (or (eq actor.flags.starwarsffg.config.enableObligation undefined) (eq actor.flags.starwarsffg.config.enableObligation true) )}}
       <div class="resource full">
         <div class="attribute flex-group-center">

--- a/templates/parts/shared/ffg-block.html
+++ b/templates/parts/shared/ffg-block.html
@@ -4,7 +4,7 @@
       <div class="block-title">
         {{#if headerlink}}
         <a class="{{headerclass}}" {{{headerattributes}}}>{{localize title}}</a>
-        {{else}} {{localize title}} {{/if}}{{#if (eq title "SWFFG.DescriptionXP")}}<a class="alt-tab" data-tab="xp"><i class="far fa-note"></i></a>{{/if}}
+        {{else}} {{localize title}}{{/if}}
       </div>
       <div class="block-attribute">
         {{#if (eq blocktype "pills")}}
@@ -44,7 +44,7 @@
         {{/if}} {{#if (eq type "PopoutEditor")}}
         <div class="block-value block-single">
           <div class="popout-editor" data-target="{{name}}" data-value="{{value}}" data-label="{{localize title}}">
-            <div class="popout-editor-button"><i class="fas fa-edit"></i></div>
+            <div class="popout-editor-button">{{#if readonly}}{{ else }}<i class="fas fa-edit"></i>{{/if}}</div>
             {{{value}}}
           </div>
         </div>


### PR DESCRIPTION
* moves all obligation/duty/conflict/morality info to a dedicated tab (leaving the bio tab for the biography only)
* moves the XP available/total fields to the XP log tab
* stops showing edit button on XP log, as it is currently read only

#1473