### PR TITLE
Improved TextEditor enrichers for nested tag parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+`1.902`
+* Fixes:
+  * Improves nested tag formatting (e.g., allows for strings like `[B]Average ([di][di]) Skill[b]` to properly render)
+
 `1.901`
 * Features:
   * Added a sheet option to disable Force Pool on Rival and Nemesis actor sheets ([#1502](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1502))

--- a/modules/helpers/journal.js
+++ b/modules/helpers/journal.js
@@ -319,7 +319,7 @@ export function register_dice_enricher() {
 
 export function register_oggdude_tag_enricher() {
   CONFIG.TextEditor.enrichers.push({
-    pattern: /(\[B\])(.[^\[]*)\[b\]/gm,
+    pattern: /(\[B\])(((?!\[b\]).)*)(\[b\])/gm,
     enricher: async (match, options) => {
         let element = document.createElement("span");
         element.classList.add("bold");
@@ -342,7 +342,7 @@ export function register_oggdude_tag_enricher() {
       }
   });
   CONFIG.TextEditor.enrichers.push({
-    pattern: /(\[I\])(.[^\[]*)\[i\]/gm,
+    pattern: /(\[I\])(((?!\[i\]).)*)\[i\]/gm,
     enricher: async (match, options) => {
         let element = document.createElement("span");
         element.classList.add("italic");
@@ -351,7 +351,7 @@ export function register_oggdude_tag_enricher() {
       }
   });
   CONFIG.TextEditor.enrichers.push({
-    pattern: /(\[H1\])(.[^\[]*)\[h1\]/gm,
+    pattern: /(\[H1\])(((?!\[h1\]).)*)\[h1\]/gm,
     enricher: async (match, options) => {
         let element = document.createElement("h1");
         element.textContent = match[2];
@@ -359,7 +359,7 @@ export function register_oggdude_tag_enricher() {
       }
   });
   CONFIG.TextEditor.enrichers.push({
-    pattern: /(\[H2\])(.[^\[]*)\[h2\]/gm,
+    pattern: /(\[H2\])(((?!\[h2\]).)*)\[h2\]/gm,
     enricher: async (match, options) => {
         let element = document.createElement("h2");
         element.textContent = match[2];
@@ -367,7 +367,7 @@ export function register_oggdude_tag_enricher() {
       }
   });
   CONFIG.TextEditor.enrichers.push({
-    pattern: /(\[H3\])(.[^\[]*)\[h3\]/gm,
+    pattern: /(\[H3\])(((?!\[h3\]).)*)\[h3\]/gm,
     enricher: async (match, options) => {
       let element = document.createElement("h3");
       element.textContent = match[2];
@@ -375,7 +375,7 @@ export function register_oggdude_tag_enricher() {
     }
   });
   CONFIG.TextEditor.enrichers.push({
-    pattern: /(\[H4\])(.[^\[]*)\[h4\]/gim,
+    pattern: /(\[H4\])(((?!\[h4\]).)*)\[h4\]/gim,
     enricher: async (match, options) => {
         let element = document.createElement("h3"); // h4 doesn't exist
         element.textContent = match[2];


### PR DESCRIPTION
Updates the RegExp used when processing tags (`[B]`, etc); allows the processor to properly convert nested tags (e.g., `[B]Average ([di][di]) check[b]`.

Side thought: it may not even be necessary to worry about enclosing many of these tags (from `[B]...[b]` to `<b>...</b>`) -- you could probably just do a straight `[B]` -> `<b>` / `[b]` -> `</b>` and it'll be fine.