### PR TITLE
Modifications to the Specialization Sheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 cypress/audio/
 cypress/videos/
 cypress/screenshots/
+
+packs

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@ node_modules
 cypress/audio/
 cypress/videos/
 cypress/screenshots/
-
-packs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+`1.902`
+* Features:
+  * Modified the Specialization sheet; moved the XP cost off of the talents, changed the appearance of talent connections, and improved how the sheet scales when the window is resized.
+  * Increased the default size of the popout editor (e.g., used for editing the description of a Specialization)
+* Fixes:
+  * Removed the "purchase" context menu option when editing a Specialization that is not attached to a character
+
 `1.901`
 * Features:
   * Added a sheet option to disable Force Pool on Rival and Nemesis actor sheets ([#1502](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1502))

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -145,7 +145,8 @@ export class ItemSheetFFG extends ItemSheet {
         }
         break;
       case "specialization":
-        this.position.width = 715;
+        this.position.width = 850;
+        this.position.height = 1005;
         data.isReadOnly = false;
         if (!this.options.editable) {
           data.isEditing = false;
@@ -309,33 +310,38 @@ export class ItemSheetFFG extends ItemSheet {
   /** @override */
   activateListeners(html) {
     super.activateListeners(html);
-    new ContextMenu(html, ".talent-upgrade.specialization-talent", [
-      {
-        name: game.i18n.localize("SWFFG.Actors.Sheets.Purchase.Talent.ContextMenuText"),
-        icon: '<i class="fas fa-dollar"></i>',
-        callback: (li) => {
-          this._buyTalent(li);
+    
+    // Prevent "purchase" context menu options when editing a sheet not attached to a character.
+    const isOwned = this.object?.flags?.starwarsffg?.ffgIsOwned;
+    if (isOwned) {
+      new ContextMenu(html, ".talent-upgrade.specialization-talent", [
+        {
+          name: game.i18n.localize("SWFFG.Actors.Sheets.Purchase.Talent.ContextMenuText"),
+          icon: '<i class="fas fa-dollar"></i>',
+          callback: (li) => {
+            this._buyTalent(li);
+          },
         },
-      },
-    ]);
-    new ContextMenu(this.element, ".talent-upgrade.force-power", [
-      {
-        name: game.i18n.localize("SWFFG.Actors.Sheets.Purchase.FP.ContextMenuText"),
-        icon: '<i class="fas fa-dollar"></i>',
-        callback: (li) => {
-          this._buyForcePower(li);
+      ]);
+      new ContextMenu(this.element, ".talent-upgrade.force-power", [
+        {
+          name: game.i18n.localize("SWFFG.Actors.Sheets.Purchase.FP.ContextMenuText"),
+          icon: '<i class="fas fa-dollar"></i>',
+          callback: (li) => {
+            this._buyForcePower(li);
+          },
         },
-      },
-    ]);
-    new ContextMenu(this.element, ".talent-upgrade.signature-ability", [
-      {
-        name: game.i18n.localize("SWFFG.Actors.Sheets.Purchase.SA.ContextMenuText"),
-        icon: '<i class="fas fa-dollar"></i>',
-        callback: (li) => {
-          this._buySignatureAbility(li);
+      ]);
+      new ContextMenu(this.element, ".talent-upgrade.signature-ability", [
+        {
+          name: game.i18n.localize("SWFFG.Actors.Sheets.Purchase.SA.ContextMenuText"),
+          icon: '<i class="fas fa-dollar"></i>',
+          callback: (li) => {
+            this._buySignatureAbility(li);
+          },
         },
-      },
-    ]);
+      ]);
+    }
 
     // register sheet options
     if (["gear", "weapon", "armour"].includes(this.object.type)) {
@@ -1160,7 +1166,7 @@ export class ItemSheetFFG extends ItemSheet {
     const parent = $(a.parentElement);
     const parentPosition = $(parent).offset();
 
-    const windowHeight = parseInt($(parent).height(), 10) + 100 < 200 ? 200 : parseInt($(parent).height(), 10) + 100;
+    const windowHeight = parseInt($(parent).height(), 10) + 100 < 400 ? 400 : parseInt($(parent).height(), 10) + 100;
     const windowWidth = parseInt($(parent).width(), 10) < 320 ? 320 : parseInt($(parent).width(), 10);
     const windowLeft = parseInt(parentPosition.left, 10);
     const windowTop = parseInt(parentPosition.top, 10);

--- a/styles/mandar.css
+++ b/styles/mandar.css
@@ -988,9 +988,50 @@ img {
   position: relative;
 }
 
+.starwarsffg .talent-grid.specialization-grid {
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: column;
+  position: relative;
+  height: calc(100% - 15px);
+  max-height: calc(100% - 15px);
+}
+
+.starwarsffg .talent-grid .talent-tier-row {
+  flex: 1 0 16%;
+  display: flex;
+  flex-direction: row;
+  max-height: 20%;
+}
+
+.starwarsffg .talent-grid .talent-tier-row-label {
+  flex: 0 0 30px;
+  max-width: 30px;
+}
+.starwarsffg .talent-grid .talent-tier-row-label .talent-tier-row-label-text {
+  transform: rotate(-90deg);
+  transform-origin: bottom right;
+  width: auto;
+  height: 1rem;
+  line-height: 1rem;
+  text-align: center;
+  font-size: 1.1rem;
+  margin-left: -6rem;
+  overflow: visible;
+  text-wrap: nowrap;
+}
+
+.starwarsffg .talent-grid .talent-tier-row .talent-body > input {
+  background-color: rgba(0, 0, 0, 0.125);
+  font-size: 0.8rem;
+  height: 1.1rem;
+  margin-bottom: 5px;
+}
+
 .starwarsffg .talent-upgrade {
   position: relative;
   margin: 10px 10px 5px 10px;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.7);
 }
 
 .starwarsffg .talent-upgrade .talent-actions {
@@ -1062,6 +1103,7 @@ img {
   z-index: 10;
   background-color: #ddd;
   padding: 5px;
+  height: 100%;
   --notchSize: 0.25rem;
   -webkit-clip-path: polygon(0% 0, var(--notchSize) 0%, calc(100% - var(--notchSize)) 0%, 100% var(--notchSize), 100% calc(100% - var(--notchSize)), calc(100% - var(--notchSize)) 100%, var(--notchSize) 100%, 0% calc(100% - var(--notchSize)));
   clip-path: polygon(0% 0, var(--notchSize) 0%, calc(100% - var(--notchSize)) 0%, 100% var(--notchSize), 100% calc(100% - var(--notchSize)), calc(100% - var(--notchSize)) 100%, var(--notchSize) 100%, 0% calc(100% - var(--notchSize)));
@@ -1089,6 +1131,16 @@ img {
   text-align: right;
 }
 
+.starwarsffg .talent-grid .talent-background .talent-header div.talent-name {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  max-width: calc(100% - 25px);
+  line-height: 1rem;
+  font-size: 0.9rem;
+  text-align: right;
+}
+
 .starwarsffg .talent-background .talent-header div.talent-name.talent-modifiers {
   cursor: pointer;
 }
@@ -1112,6 +1164,10 @@ img {
   padding: 0;
   line-height: 0.75rem;
   width: 1rem;
+}
+
+.starwarsffg .talent-tier-row .talent-background .talent-body {
+  height: 100%;
 }
 
 .starwarsffg .talent-background.talent-active .talent-header {
@@ -1166,7 +1222,7 @@ img {
 
 .starwarsffg .talent-connection-point-top {
   position: absolute;
-  top: -6px;
+  top: -7px;
   left: 50%;
   transform: translateX(-50%);
   width: 100%;
@@ -1232,35 +1288,51 @@ img {
   display: inline-block;
   width: 34px;
   height: 12px;
-  background-color: black;
+  background-color: white;
+  box-shadow: 0px 0px 25px red;
   position: absolute;
   top: -3px;
 }
 
+/* Some various color schemes for talent connectors */
+.lightsaber-red {
+  background-color: white !important;
+  box-shadow: 0px 0px 25px red !important;
+}
+.lightsaber-blue {
+  background-color: white !important;
+  box-shadow: 0px 0px 25px blue !important;
+}
+.lightsaber-purple {
+  background-color: white !important;
+  box-shadow: 0px 0px 25px purple !important;
+}
+
+
 .starwarsffg .talent-connector .talent-connector-up i,
 .starwarsffg .talent-connector .talent-connector-side i {
   display: initial;
-  color: white;
+  color: black;
 }
 
 .starwarsffg .talent-connector .talent-connector-up {
-  height: 100px;
-  top: -50px;
+  height: 35px;
+  width: 20px;
+  top: -10px;
   z-index: 5;
 }
 
 .starwarsffg .talent-connector .talent-connector-up i {
   position: absolute;
-  top: 50%;
+  top: 25%;
   left: 0;
-  width: 34px;
+  width: 20px;
 }
 
 .starwarsffg .talent-connector .talent-connector-side {
   width: 35px;
-  height: 35px;
+  height: 20px;
   left: -15px;
-  padding-top: 8px;
 }
 
 .starwarsffg .talent-disable-edit .talent-actions {
@@ -1271,7 +1343,7 @@ img {
   display: none !important;
 }
 
-.starwarsffg .talent-disable-edit i {
+.starwarsffg .talent-disable-edit i.talent-button {
   display: none !important;
 }
 .starwarsffg .talent-action {
@@ -3491,7 +3563,7 @@ img {
 }
 
 .starwarsffg .item-sheet-specialization .sheet-body {
-  height: calc(100% - 10.5rem);
+  height: calc(100% - 9.5rem);
   margin: 0;
   padding: 0;
   word-break: break-word;

--- a/templates/items/ffg-specialization-sheet.html
+++ b/templates/items/ffg-specialization-sheet.html
@@ -27,52 +27,68 @@
 
   {{!-- Sheet Body --}}
   <section class="sheet-body">
-    <div class="talent-grid {{#if data.isEditing}}{{else}}talent-disable-edit{{/if}}">
+    <div class="talent-grid specialization-grid {{#if data.isEditing}}{{else}}talent-disable-edit{{/if}}">
       {{#each data.talents as |talent key|}}
 
-      <div class="talent-block talent-upgrade talent-single specialization-talent" id="{{key}}" data-itemid="{{talent.itemId}}" data-cost="{{calculateSpecializationTalentCost key}}" data-base-item-name="{{../item.name}}">
-        <div class="talent-background {{#iff talent.activationLabel 'contains' 'Passive'}}talent-passive{{else}}talent-active{{/iff}}">
-          <div class="talent-header">
-            <div>
-              {{#if talent.isForceTalent}}
-              <div class="burst-8"></div>
-              {{/if}} <input type="checkbox" class="{{#if talent.isConflictTalent}}conflict{{/if}}" name="data.talents.{{key}}.islearned" data-dtype="Boolean" {{#if talent.islearned }}checked{{else}} {{/if}}> {{#if talent.isConflictTalent}}
-              <div class="conflict"></div>
-              {{/if}}
-            </div>
-            <div class="talent-name {{#if (ne talent.name '')}}talent-modifiers{{/if}}" data-name="{{talent.name}}">{{{talent.name}}} <span>COST: {{calculateSpecializationTalentCost key}}</span></div>
-          </div>
-          <div class="talent-body">
-            <input type="text" value="{{localize talent.activationLabel}}" disabled />
-            {{{ talent.enrichedDescription}}}
-            <div class="talent-hidden">
-              <input class="talent-hidden" type="text" name="data.talents.{{key}}.name" value="{{talent.name}}" />
-              <input class="talent-hidden" type="text" name="data.talents.{{key}}.enrichedDescription" value="{{talent.enrichedDescription}}" />
-              <input class="talent-hidden" type="text" name="data.talents.{{key}}.activation" value="{{talent.activation}}" />
-              <input class="talent-hidden" type="text" name="data.talents.{{key}}.activationLabel" value="{{talent.activationLabel}}" />
-              <input class="talent-hidden" type="text" name="data.talents.{{key}}.itemId" value="{{talent.itemId}}" />
-              <input class="talent-hidden" type="text" name="data.talents.{{key}}.isRanked" value="{{talent.isRanked}}" data-dtype="Boolean" />
-              <input class="talent-hidden" type="text" name="data.talents.{{key}}.pack" value="{{talent.pack}}" />
-              <input class="talent-hidden" type="text" name="data.talents.{{key}}.cost" value="{{calculateSpecializationTalentCost key}}" />
-              <input class="talent-hidden" type="checkbox" name="data.talents.{{key}}.isForceTalent" data-dtype="Boolean" {{checked talent.isForceTalent}} />
+        {{#if (eq (math @index '%' 4) 0)}}
+        <div class="talent-tier-row">
+          <div class="talent-tier-row-label">
+            <div class="talent-tier-row-label-text">
+              {{localize 'SWFFG.Cost'}} <b>{{calculateSpecializationTalentCost key}}</b> {{localize 'SWFFG.DescriptionXP'}}
             </div>
           </div>
+        {{/if}}
+
+          <div class="talent-block talent-upgrade talent-single specialization-talent" id="{{key}}" data-itemid="{{talent.itemId}}" data-cost="{{calculateSpecializationTalentCost key}}" data-base-item-name="{{../item.name}}">
+            <div class="talent-background {{#iff talent.activationLabel 'contains' 'Passive'}}talent-passive{{else}}talent-active{{/iff}}">
+              <div class="talent-header">
+                <div>
+                  {{#if talent.isForceTalent}}
+                  <div class="burst-8"></div>
+                  {{/if}} <input type="checkbox" class="{{#if talent.isConflictTalent}}conflict{{/if}}" name="data.talents.{{key}}.islearned" data-dtype="Boolean" {{#if talent.islearned }}checked{{else}} {{/if}}> {{#if talent.isConflictTalent}}
+                  <div class="conflict"></div>
+                  {{/if}}
+                </div>
+                <div class="talent-name {{#if (ne talent.name '')}}talent-modifiers{{/if}}" data-name="{{talent.name}}">
+                  {{{talent.name}}}
+                </div>
+              </div>
+              <div class="talent-body">
+                <input type="text" value="{{localize talent.activationLabel}}" disabled />
+                {{{ talent.enrichedDescription}}}
+                <div class="talent-hidden">
+                  <input class="talent-hidden" type="text" name="data.talents.{{key}}.name" value="{{talent.name}}" />
+                  <input class="talent-hidden" type="text" name="data.talents.{{key}}.enrichedDescription" value="{{talent.enrichedDescription}}" />
+                  <input class="talent-hidden" type="text" name="data.talents.{{key}}.activation" value="{{talent.activation}}" />
+                  <input class="talent-hidden" type="text" name="data.talents.{{key}}.activationLabel" value="{{talent.activationLabel}}" />
+                  <input class="talent-hidden" type="text" name="data.talents.{{key}}.itemId" value="{{talent.itemId}}" />
+                  <input class="talent-hidden" type="text" name="data.talents.{{key}}.isRanked" value="{{talent.isRanked}}" data-dtype="Boolean" />
+                  <input class="talent-hidden" type="text" name="data.talents.{{key}}.pack" value="{{talent.pack}}" />
+                  <input class="talent-hidden" type="text" name="data.talents.{{key}}.cost" value="{{calculateSpecializationTalentCost key}}" />
+                  <input class="talent-hidden" type="checkbox" name="data.talents.{{key}}.isForceTalent" data-dtype="Boolean" {{checked talent.isForceTalent}} />
+                </div>
+              </div>
+            </div>
+            <div class="talent-connections">
+              <div class="talent-connection-point-top">
+                <div class="{{#if talent.links-top-1}}talent-connector{{/if}} talent-action {{#if talent.canLinkTop}}talent-connection-point-top{{else}}talent-hidden{{/if}} talent-{{talent.size}}" data-action="link-top" data-key="{{key}}" data-linknumber="1">
+                  <i class="fas fa-chevron-up talent-button"></i>
+                  <div class="talent-connector-up lightsaber-red"><i class="fas fa-chevron-down talent-button"></i></div>
+                  <input class="talent-hidden" name="data.talents.{{key}}.links-top-1" type="text" value="{{talent.links-top-1}}" data-dtype="Boolean" />
+                </div>
+              </div>
+              <div class="{{#if talent.links-right}}talent-connector{{/if}} talent-action {{#if talent.canLinkRight}}talent-connection-point-right{{else}}talent-hidden{{/if}}" data-action="link-right" data-key="{{key}}">
+                <i class="fas fa-chevron-right talent-button"></i>
+                <div class="talent-connector-side lightsaber-red"><i class="fas fa-chevron-right talent-button"></i><i class="fas fa-chevron-left talent-button"></i></div>
+                <input class="talent-hidden" name="data.talents.{{key}}.links-right" type="text" value="{{talent.links-right}}" data-dtype="Boolean" />
+              </div>
+            </div>
+          </div>
+
+        {{#if (eq (math (math @index '+' 1) '%' 4) 0)}}
         </div>
-        <div class="talent-connections">
-          <div class="talent-connection-point-top">
-            <div class="{{#if talent.links-top-1}}talent-connector{{/if}} talent-action {{#if talent.canLinkTop}}talent-connection-point-top{{else}}talent-hidden{{/if}} talent-{{talent.size}}" data-action="link-top" data-key="{{key}}" data-linknumber="1">
-              <i class="fas fa-chevron-up"></i>
-              <div class="talent-connector-up"><i class="fas fa-chevron-down"></i></div>
-              <input class="talent-hidden" name="data.talents.{{key}}.links-top-1" type="text" value="{{talent.links-top-1}}" data-dtype="Boolean" />
-            </div>
-          </div>
-          <div class="{{#if talent.links-right}}talent-connector{{/if}} talent-action {{#if talent.canLinkRight}}talent-connection-point-right{{else}}talent-hidden{{/if}}" data-action="link-right" data-key="{{key}}">
-            <i class="fas fa-chevron-right"></i>
-            <div class="talent-connector-side"><i class="fas fa-chevron-right"></i><i class="fas fa-chevron-left"></i></div>
-            <input class="talent-hidden" name="data.talents.{{key}}.links-right" type="text" value="{{talent.links-right}}" data-dtype="Boolean" />
-          </div>
-        </div>
-      </div>
+        {{/if}}
+
       {{/each}}
     </div>
     <div class="hidden-content">


### PR DESCRIPTION
- Modifies the size of the window; scales the talent blocks as the window resizes; updates the appearance of the talent connectors
- Increases the default size of the pop-out editor

This is a small overhaul of the Specialization sheet, intended to improve legibility and add better scaling.

**Updated Sheet:**
![image](https://github.com/StarWarsFoundryVTT/StarWarsFFG/assets/14201506/e408b3fb-42a0-417e-b4f8-b10e1b9d1cbd)

**Scaling:**
![image](https://github.com/StarWarsFoundryVTT/StarWarsFFG/assets/14201506/787ccc71-13cf-42e2-84d3-ec8aa0de5370)

Question: Is there no sass/scss source for the mandar theme?