### PR TITLE
fix(specialization): Updating a talent from a tree updates the tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   * Non FFG Dice rolls with multiple terms are accepted again ([#1664](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1664))
   * Escape menu toggles in the normal way again ([#1670](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1670))
   * Force Power: Empty mod list doesn't reset basic force power anymore ([#1669](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1669))
+  * Updating a talent from a specialization tree updates the tree ([#1643](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1643))
 
 `1.903`
 * Features:

--- a/modules/helpers/item-helpers.js
+++ b/modules/helpers/item-helpers.js
@@ -53,7 +53,7 @@ export default class ItemHelpers {
           if (spec) {
             let updateData = {};
             foundry.utils.setProperty(updateData, `data.talents.${parent.talent}.name`, formData.name);
-            foundry.utils.setProperty(updateData, `data.talents.${parent.talent}.description`, formData.data.description);
+            foundry.utils.setProperty(updateData, `data.talents.${parent.talent}.description`, this.object.system.description);
             foundry.utils.setProperty(updateData, `data.talents.${parent.talent}.activation`, formData.data.activation.value);
             foundry.utils.setProperty(updateData, `data.talents.${parent.talent}.isRanked`, formData.data.ranks.ranked);
             foundry.utils.setProperty(updateData, `data.talents.${parent.talent}.isForceTalent`, formData.data.isForceTalent);

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -58,7 +58,7 @@ export class ItemSheetFFG extends ItemSheet {
       );
     });
     // this is the end of the de-duplicating -=key stuff
-
+    
     data.data = data.item.system;
 
 
@@ -383,7 +383,7 @@ export class ItemSheetFFG extends ItemSheet {
     });
 
     if (this.object.type === "talent") {
-      if (!Hooks?.events[`closeAssociatedTalent_${this.object._id}`]?.length && typeof this._submitting === "undefined") {
+      if (!Hooks?.events[`closeAssociatedTalent_${this.object._id}`]?.length && (typeof this._submitting === "undefined" || this._priorState <= 0)) {
         Hooks.once(`closeAssociatedTalent_${this.object._id}`, (item) => {
           item.object.flags.clickfromparent = [];
           Hooks.off(`closeAssociatedTalent_${item.object._id}`);

--- a/modules/items/itembase-ffg.js
+++ b/modules/items/itembase-ffg.js
@@ -5,6 +5,7 @@ export default class ItemBaseFFG extends Item {
   async update(data, options = {}) {
     if ((!this.flags?.starwarsffg?.ffgTempId && this.flags?.starwarsffg?.ffgTempId !== null) || (this.flags?.starwarsffg?.ffgTempId === this._id && this._id !== null && !this.isTemp) || (this.flags?.starwarsffg?.ffgIsOwned && !this.flags?.starwarsffg?.ffgIsTemp)) {
       CONFIG.logger.debug("Updating real item", this, data);
+      if (typeof data.flags.clickfromparent === "undefined" && !(typeof this.flags.clickfromparent === "undefined")) data.flags.clickfromparent = this.flags.clickfromparent
       await super.update(ItemHelpers.normalizeDataStructure(data), options);
       // if (this.compendium) {
       //   return this.sheet.render(true);


### PR DESCRIPTION
This PR fixes a specialization tree not being updated when talents within it are edited.

`item-helpers.js` referenced `formData.data.description` whereas the template stored the description in `system.description`.

The `clickfromparent` list was lost during a call to `Item.update`.

The modification of the hook allows it to be created every time a talent is opened, not just the first one, but it references a Foundry API private property (`_priorState`).
I think we could use the `ItemSheet.close()` method instead to reset the `clickfromparent` list. I have a commit ready if needed [here](https://github.com/obrenckle/StarWarsFFG/tree/move_hook_to_close).

Closes #1643 