### PR TITLE
fix(actor): retain token settings when copying actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * Apply Force Powers upgrades to character
   * Imported skill modifiers have better formatted attributes key names ([#1663](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1663))
   * Updated Spanish localizations
+  * Retain token settings when copying actors
 
 `1.903`
 * Fix:

--- a/modules/actors/actor-ffg.js
+++ b/modules/actors/actor-ffg.js
@@ -11,7 +11,7 @@ export class ActorFFG extends Actor {
     const createData = data;
 
     // Only apply defaults for newly created actors
-    if (!typeof data.system === "undefined") {
+    if (!(typeof data.system === "undefined")) {
       return super.create(createData, options);
     }
     


### PR DESCRIPTION
Fix an incorrect test applying token defaults (and resetting other settings) when copying actors.

Closes #1673