### PR TITLE
fix(dice): + not added before or after operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 `1.904`
 * Fixes:
-  * Apply Force Powers upgrades to character
+  * Apply Force Powers upgrades to character ([#1542](https://github.com/StarWarsFoundryVTT/StarWarsFFG/pull/1672))
   * Imported skill modifiers have better formatted attributes key names ([#1663](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1663))
   * Updated Spanish localizations
+  * Non FFG Dice rolls with multiple terms are accepted again ([#1664](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1664))
 
 `1.903`
 * Fix:

--- a/modules/dice/roll.js
+++ b/modules/dice/roll.js
@@ -409,9 +409,12 @@ export class RollFFG extends Roll {
           return acc;
         }, [])
       })
-      .flatMap((value, index, array) => //Put addition operators between each die.
-        array.length - 1 !== index
-          ? [value, new foundry.dice.terms.OperatorTerm({operator: '+'})]
-          : value)
+      .flatMap((value, index, array) => {   //Put addition operators between each die, but not before or after another Operator
+        if (array.length - 1 !== index && !(array[index] instanceof foundry.dice.terms.OperatorTerm) && !(array[index + 1] instanceof foundry.dice.terms.OperatorTerm)) {
+          return [value, new foundry.dice.terms.OperatorTerm({operator: '+'})] 
+        } else {
+          return value
+        }
+      })          
   }
 }


### PR DESCRIPTION
This PR fixes non FFG dice formula being rejected when more than one term was present.

`+` operators were systematically added between terms of the formula, e.g. `2d6 + 1` became `2d6 + + + 1`
A check has been added to only add `+` between two non operator terms.

Closes #1664 
