### PR TITLE
feat(actors): show GM characters in group manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 `1.904`
+* Features:
+  * Optionally include GM Characters in the Group Manager
 * Fixes:
   * Apply Force Powers upgrades to character ([#1542](https://github.com/StarWarsFoundryVTT/StarWarsFFG/pull/1672))
   * Imported skill modifiers have better formatted attributes key names ([#1663](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1663))

--- a/lang/en.json
+++ b/lang/en.json
@@ -763,5 +763,7 @@
   "SWFFG.DragDrop.GrantItem": "Grant",
   "SWFFG.DragDrop.XPLog": "drag-and-drop",
   "SWFFG.Settings.actor.RivalTokenPrepend.Name": "Prepend Adjective to rival tokens",
-  "SWFFG.Settings.actor.RivalTokenPrepend.Hint": "Unlinked rival's token name will be prepended with an Adjective by default. Example: \"Angry\""
+  "SWFFG.Settings.actor.RivalTokenPrepend.Hint": "Unlinked rival's token name will be prepended with an Adjective by default. Example: \"Angry\"",
+  "SWFFG.Settings.groupManager.GMCharactersInGroupManager.Name": "Show GM Characters in Group Manager",
+  "SWFFG.Settings.groupManager.GMCharactersInGroupManager.Hint": "Characters owned by a GM will be included in the Group Manager"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -731,5 +731,7 @@
   "SWFFG.DragDrop.Title": "Acheter l'objet, ou l'attribuer pour 0 XP ?",
   "SWFFG.DragDrop.PurchaseItem": "Acheter",
   "SWFFG.DragDrop.GrantItem": "Attribuer",
-  "SWFFG.DragDrop.XPLog": "glisser-déposer"
+  "SWFFG.DragDrop.XPLog": "glisser-déposer",
+  "SWFFG.Settings.groupManager.GMCharactersInGroupManager.Name": "Afficher les personnages de MJ",
+  "SWFFG.Settings.groupManager.GMCharactersInGroupManager.Hint": "Les personnes appartenant à des MJs seront inclus dans le gestionnaire de groupe"
 }

--- a/modules/groupmanager-ffg.js
+++ b/modules/groupmanager-ffg.js
@@ -60,7 +60,7 @@ export class GroupManager extends FormApplication {
    * @return {Object}   The data provided to the template when rendering the form
    */
   getData() {
-    const players = game.users.contents.filter((u) => !u.isGM && u.active);
+    const players = game.users.contents.filter((u) => (!u.isGM || game.settings.get("starwarsffg", "GMCharactersInGroupManager")) && u.active);
     if (players.length > 0) {
       players.connected = true;
     }

--- a/modules/settings/settings-helpers.js
+++ b/modules/settings/settings-helpers.js
@@ -333,6 +333,16 @@ export default class SettingsHelpers {
       default: false,
       type: Boolean,
     });
+
+    // Allow GM characters in Group manager
+    game.settings.register("starwarsffg", "GMCharactersInGroupManager", {
+      name: game.i18n.localize("SWFFG.Settings.groupManager.GMCharactersInGroupManager.Name"),
+      hint: game.i18n.localize("SWFFG.Settings.groupManager.GMCharactersInGroupManager.Hint"),
+      scope: "world",
+      config: false,
+      default: false,
+      type: Boolean,
+    });
   }
 
   // Initialize System Settings after the Ready Hook

--- a/modules/settings/ui-settings.js
+++ b/modules/settings/ui-settings.js
@@ -206,6 +206,7 @@ export class groupManagerSettings extends ffgSettings {
     const includeSettingsNames = [
       "starwarsffg.pcListMode",
       "starwarsffg.privateTriggers",
+      "starwarsffg.GMCharactersInGroupManager"
     ];
     return super.getData(includeSettingsNames);
   }


### PR DESCRIPTION
This PR is an example implementation of the option to have GM characters be treated as Player characters in the Group Manager..

The option is located in the Group Manager Settings.

![GrpMngOption](https://github.com/user-attachments/assets/b08e116b-9240-47c3-a571-34496594a907)

![GrpMngrResult](https://github.com/user-attachments/assets/68fe9cfc-65a8-47e0-822e-b663eedbdd15)

Closes #1680 