### PR TITLE
fix(ui): main menu toggles normally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Updated Spanish localizations
   * Retain token settings when copying actors
   * Non FFG Dice rolls with multiple terms are accepted again ([#1664](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1664))
+  * Escape menu toggles in the normal way again ([#1670](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1670))
 
 `1.903`
 * Fix:

--- a/modules/ffg-destiny-tracker.js
+++ b/modules/ffg-destiny-tracker.js
@@ -62,13 +62,7 @@ export default class DestinyTracker extends FormApplication {
   _updateObject(event, formData) {};
 
   /** @override */
-  async close(options = {}) {
-    let menu = $("#menu");
-    if (menu.length === 0) {
-      menu = new MainMenu();
-    }
-      menu.toggle();
-  };
+  async close(options = {}) {};
 
   /** @override */
   activateListeners(html) {


### PR DESCRIPTION
This PR tentatively fixes the main menu not being toggled with the escape key, except with a token selected.

Hitting the escape key triggers the first of a bunch of ui changes. The ones that interest us here are:
- close at least a window
- unselect a token
- toggle the main menu

The group manager/destiny tracker is always open, so "close a window" was always triggered on it, but its close method doesn't actually close it, as it mus remain visible.  Instead it contains the main menu toggle code.

No window being actually closed means we stop at "unselect a token" if one is selected, or "toggle the main menu" *again* if not.

*Tentatively* because I couldn't find why the main menu toggle code was here, and I'm not sure if I'm not missing something.

Closes #1670 