### PR TITLE
fix(item): improves itembase logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Escape menu toggles in the normal way again ([#1670](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1670))
   * Force Power: Empty mod list doesn't reset basic force power anymore ([#1669](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1669))
   * Updating a talent from a specialization tree updates the tree ([#1643](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1643))
+  * Get embedded item data from `system` variable instead of root
 
 `1.903`
 * Features:

--- a/modules/items/itembase-ffg.js
+++ b/modules/items/itembase-ffg.js
@@ -28,7 +28,7 @@ export default class ItemBaseFFG extends Item {
         const appId = this?.flags?.starwarsffg?.ffgParentApp;
         if (appId) {
           const newData = ui.windows[appId].object;
-          newData[this.flags.starwarsffg.ffgTempItemType][this.flags.starwarsffg.ffgTempItemIndex] = mergeObject(newData[this.flags.starwarsffg.ffgTempItemType][this.flags.starwarsffg.ffgTempItemIndex], this);
+          newData.system[this.flags.starwarsffg.ffgTempItemType][this.flags.starwarsffg.ffgTempItemIndex] = mergeObject(newData.system[this.flags.starwarsffg.ffgTempItemType][this.flags.starwarsffg.ffgTempItemIndex], this);
           await ui.windows[appId].render(true, { action: "ffgUpdate", data: newData });
         }
         return;

--- a/modules/items/itembase-ffg.js
+++ b/modules/items/itembase-ffg.js
@@ -5,7 +5,7 @@ export default class ItemBaseFFG extends Item {
   async update(data, options = {}) {
     if ((!this.flags?.starwarsffg?.ffgTempId && this.flags?.starwarsffg?.ffgTempId !== null) || (this.flags?.starwarsffg?.ffgTempId === this._id && this._id !== null && !this.isTemp) || (this.flags?.starwarsffg?.ffgIsOwned && !this.flags?.starwarsffg?.ffgIsTemp)) {
       CONFIG.logger.debug("Updating real item", this, data);
-      if (typeof data.flags.clickfromparent === "undefined" && !(typeof this.flags.clickfromparent === "undefined")) data.flags.clickfromparent = this.flags.clickfromparent
+      if (typeof data.flags?.clickfromparent === "undefined" && typeof this.flags?.clickfromparent !== "undefined") data.flags.clickfromparent = this.flags.clickfromparent
       await super.update(ItemHelpers.normalizeDataStructure(data), options);
       // if (this.compendium) {
       //   return this.sheet.render(true);


### PR DESCRIPTION
This PR fixes an error occurring when checking data.flags.clickfromparent type while data.flags doesn't exists and one incorrect path using data instead of data.system.

Closes #1689 