### PR TITLE
fix(import): Use correct type for Force Boost mods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Escape menu toggles in the normal way again ([#1670](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1670))
   * Force Power: Empty mod list doesn't reset basic force power anymore ([#1669](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1669))
   * Updating a talent from a specialization tree updates the tree ([#1643](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1643))
+  * Use correct type when importing a Force Boost mods ([#1687](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1687))
 
 `1.903`
 * Features:

--- a/modules/importer/import-helpers.js
+++ b/modules/importer/import-helpers.js
@@ -333,6 +333,10 @@ export default class ImportHelpers {
           modtype = "Skill Remove Setback";
           value = parseInt(mod.SetbackCount, 10);
         }
+        if (mod.ForceCount) {
+          modtype = "Force Boost"
+          value = true;
+        }
         if (mod.BoostCount) {
           value = parseInt(mod.BoostCount, 10);
         }
@@ -2431,6 +2435,10 @@ export default class ImportHelpers {
         if (mod.SetbackCount) {
           modtype = "Skill Remove Setback";
           value = parseInt(mod.SetbackCount, 10);
+        }
+        if (mod.ForceCount) {
+          modtype = "Force Boost"
+          value = true;
         }
         if (mod.BoostCount) {
           value = parseInt(mod.BoostCount, 10);


### PR DESCRIPTION
This PR fixes Force Boost mods being imported as Skill Boost mods.

Closes #1687 