### PR TITLE
fix(items): Add parent item uuid to qualities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   * Get embedded item data from `system` variable instead of root
   * Use correct type when importing a Force Boost mods ([#1687](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1687))
   * Item attachments' mods use parent item mod type when present ([#1624](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1624))
+  * Qualities are linked to parent item ([#1612](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1612))
 
 `1.903`
 * Features:

--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -72,7 +72,7 @@ export class ItemFFG extends ItemBaseFFG {
       if (this.compendium) {
         item.flags.starwarsffg.isCompendium = true;
         // Temporary check on this.parent.data to avoid initialisation failing in Foundry VTT 0.8.6
-        if (this.parent?.system) item.flags.starwarsffg.ffgUuid = this.uuid;
+        item.flags.starwarsffg.ffgUuid = this.uuid;
       } else {
         item.flags.starwarsffg.isCompendium = false;
         item.flags.starwarsffg.ffgIsOwned = false;

--- a/modules/items/itembase-ffg.js
+++ b/modules/items/itembase-ffg.js
@@ -16,8 +16,8 @@ export default class ItemBaseFFG extends Item {
       const preState = Object.values(this.apps)[0]?._state;
       await EmbeddedItemHelpers.updateRealObject(this, data);
 
-      if (this.flags?.starwarsffg?.ffgParent?.isCompendium || Object.values(this.apps)[0]._state !== preState) {
-        if (this.flags?.starwarsffg?.ffgParent?.ffgUuid) {
+      if (this.flags?.starwarsffg?.ffgParent?.starwarsffg?.isCompendium || Object.values(this.apps)[0]?._state !== preState) {
+        if (this.flags?.starwarsffg?.ffgParent?.starwarsffg?.ffgUuid) {
           this.sheet.render(false);
         }
       } else {


### PR DESCRIPTION
This PR remove the hardcoded destiny tracker window size, allowing it to grow and shrink.
This is only a partial fix for #1688, as the UI still has to be reloaded before the window will shrink or grow, but I couldn't find how to trigger a window redraw (which hook to use).