### PR TITLE
fix(ui): remove destiny tracker hardcoded size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * Item attachments' mods use parent item mod type when present ([#1624](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1624))
   * Talent cost set when preparing tree instead of template ([#1704](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1704))
   * Qualities are linked to parent item ([#1612](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1612))
+  * Remove Destiny Tracker hardcoded size, allowing it to grow and shrink when font size is changed ([#1688](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1688))
 
 `1.903`
 * Features:

--- a/modules/ffg-destiny-tracker.js
+++ b/modules/ffg-destiny-tracker.js
@@ -40,8 +40,8 @@ export default class DestinyTracker extends FormApplication {
 
     this.position.left = x - 505;
     this.position.top = y;
-    this.position.width = 150;
-    this.position.height = 105;
+    //this.position.width = 150;
+    //this.position.height = 105;
 
     // filter menu based on role.
 


### PR DESCRIPTION
This PR remove the hardcoded destiny tracker window size, allowing it to grow and shrink.
This is only a partial fix for #1688, as the UI still has to be reloaded before the window will shrink or grow, but I couldn't find how to trigger a window redraw (which hook to use).