### PR TITLE
fix(items): Set talent cost when preparing Tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   * Get embedded item data from `system` variable instead of root
   * Use correct type when importing a Force Boost mods ([#1687](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1687))
   * Item attachments' mods use parent item mod type when present ([#1624](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1624))
+  * Talent cost set when preparing tree instead of template ([#1704](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1704))
 
 `1.903`
 * Features:

--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -371,6 +371,11 @@ export class ItemFFG extends ItemBaseFFG {
           }
         }
 
+        if (itemType === "talent") {
+          const id = parseInt(upgrade.replace("talent", ""), 10);          
+          talents[upgrade].cost = (Math.trunc(id / 4) + 1) * 5;
+        }
+
         if (typeof talents[upgrade].visible === "undefined") {
           talents[upgrade].visible = true;
         }

--- a/templates/items/ffg-specialization-sheet.html
+++ b/templates/items/ffg-specialization-sheet.html
@@ -71,7 +71,7 @@
                   <input class="talent-hidden" type="text" name="data.talents.{{key}}.itemId" value="{{talent.itemId}}" />
                   <input class="talent-hidden" type="text" name="data.talents.{{key}}.isRanked" value="{{talent.isRanked}}" data-dtype="Boolean" />
                   <input class="talent-hidden" type="text" name="data.talents.{{key}}.pack" value="{{talent.pack}}" />
-                  <input class="talent-hidden" type="text" name="data.talents.{{key}}.cost" value="{{calculateSpecializationTalentCost key}}" />
+                  <input class="talent-hidden" type="text" name="data.talents.{{key}}.cost" value="{{talent.cost}}" />
                   <input class="talent-hidden" type="checkbox" name="data.talents.{{key}}.isForceTalent" data-dtype="Boolean" {{checked talent.isForceTalent}} />
                 </div>
               </div>


### PR DESCRIPTION
This PR fixes talent cost not being initialized the first time a spec is open.

Closes #1704 