### PR TITLE
fix(items): assign correct internal mod type to armor attachements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   * Qualities are linked to parent item ([#1612](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1612))
   * Assign correct modifiers type to armor: "armour" instead of "armor" ([#1697](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1697))
   * Remove Destiny Tracker hardcoded size, allowing it to grow and shrink when font size is changed ([#1688](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1688))
+  * Assign correct modifiers type to armor: "armour" instead of "armor" ([#1697](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1697))
 
 `1.903`
 * Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * Item attachments' mods use parent item mod type when present ([#1624](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1624))
   * Talent cost set when preparing tree instead of template ([#1704](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1704))
   * Qualities are linked to parent item ([#1612](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1612))
+  * Assign correct modifiers type to armor: "armour" instead of "armor" ([#1697](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1697))
 
 `1.903`
 * Features:

--- a/modules/importer/oggdude/importers/item-attachments.js
+++ b/modules/importer/oggdude/importers/item-attachments.js
@@ -46,21 +46,24 @@ export default class ItemAttachments {
             metadata: {
               tags: [],
             },
-          };
+          };          
 
           if (item?.Type?.toLowerCase() === "vehicle") {
             data.data.metadata.tags.push("shipattachment");
           } else {
             data.data.metadata.tags.push("itemattachment");
           }
-
-          try {
-            // attempt to select the specific compendium for this type of attachment
+          
+          // attempt to select the specific compendium for this type of attachment
+          if (Object.keys(packMap).includes(data.data.type)) {
             pack = packMap[data.data.type];
-          } catch (err) {
+          } else {
             // but fail back to the generic compendium
             pack = packMap["all"];
           }
+          
+          // oggdude use "armor", but the internal mod type is "armour"
+          if (data?.data?.type === "armor") data.data.type = "armour"
 
           data.data.description += ImportHelpers.getSources(item?.Sources ?? item?.Source);
           const mods = await ImportHelpers.processMods(item);

--- a/modules/importer/oggdude/importers/item-attachments.js
+++ b/modules/importer/oggdude/importers/item-attachments.js
@@ -46,21 +46,21 @@ export default class ItemAttachments {
             metadata: {
               tags: [],
             },
-          };          
+          };
 
           if (item?.Type?.toLowerCase() === "vehicle") {
             data.data.metadata.tags.push("shipattachment");
           } else {
             data.data.metadata.tags.push("itemattachment");
           }
-          
+
           // attempt to select the specific compendium for this type of attachment
           if (Object.keys(packMap).includes(data.data.type)) {
             pack = packMap[data.data.type];
           } else {
             // but fail back to the generic compendium
             pack = packMap["all"];
-          }
+          }          
           
           // oggdude use "armor", but the internal mod type is "armour"
           if (data?.data?.type === "armor") data.data.type = "armour"


### PR DESCRIPTION
This PR fixes the type of modifiers assigned to imported armor attachments.

Imported type was "armor" whereas internal type is "armour".

Closes #1697 