### PR TITLE
fix(actor): allow zero as new value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   * Remove Destiny Tracker hardcoded size, allowing it to grow and shrink when font size is changed ([#1688](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1688))
   * Assign correct modifiers type to armor: "armour" instead of "armor" ([#1697](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1697))
   * Skill purchases on actors now work via the dollar sign again ([#1713](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1713))
+  * Allows zero as a valid value when updating vehicle stats ([#1717](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1717))
 
 `1.903`
 * Features:

--- a/modules/helpers/actor-helpers.js
+++ b/modules/helpers/actor-helpers.js
@@ -125,7 +125,7 @@ export default class ActorHelpers {
             } else if (formData.data?.stats[k]?.max) {
               statValue = parseInt(formData.data.stats[k].max, 10);
             } else {
-              if (formData.data.stats[k]?.value) {
+              if (Number.isInteger(formData.data.stats[k]?.value)) {
                 statValue = parseInt(formData.data.stats[k].value, 10);
               } else {
                 statValue = 0;


### PR DESCRIPTION
This PR fixes zero not being considered a valid value when updating some vehicle stats.
`if (0)` is  false, `Number.isInteger(...)` check if a numeric value was input and accepts 0 as valid.
This closes #1717