### PR TITLE
fix(rolls): use "removed setaback dice" modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   * Skill purchases on actors now work via the dollar sign again ([#1713](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1713))
   * Allow zero as a valid value when updating vehicle stats ([#1717](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1717))
   * Replace deprecated Document.createDocuments calls with Document() constructor ([#1683](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1683))
+  * Show removed setback dice icons and optionnally remove them from all rolls ([#1720](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1720))
 
 `1.903`
 * Features:

--- a/lang/en.json
+++ b/lang/en.json
@@ -765,5 +765,7 @@
   "SWFFG.Settings.actor.RivalTokenPrepend.Name": "Prepend Adjective to rival tokens",
   "SWFFG.Settings.actor.RivalTokenPrepend.Hint": "Unlinked rival's token name will be prepended with an Adjective by default. Example: \"Angry\"",
   "SWFFG.Settings.groupManager.GMCharactersInGroupManager.Name": "Show GM Characters in Group Manager",
-  "SWFFG.Settings.groupManager.GMCharactersInGroupManager.Hint": "Characters owned by a GM will be included in the Group Manager"
+  "SWFFG.Settings.groupManager.GMCharactersInGroupManager.Hint": "Characters owned by a GM will be included in the Group Manager",
+  "SWFFG.Settings.dice.ApplyRemoveSetbackMods.Name": "Roll - Apply \"Remove setback\" mods",
+  "SWFFG.Settings.dice.ApplyRemoveSetbackMods.Hint": "Automatically apply \"Remove setback\" modifiers when rolling dice."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -437,7 +437,7 @@
   "SWFFG.AdversariesImportInstructions2": "Télécharger la source complète sous forme de fichier zip à utiliser pour l'importation.",
   "SWFFG.Skills": "Compétences",
   "SWFFG.GroupManager": "Gestionnaire de groupe",
-  "SWFFG.EnableRollAudio": "Jet - Permettre aux utilisateurs d'ajouter des sons sur les jets",
+  "SWFFG.EnableRollAudio": "Dés - Permettre aux utilisateurs d'ajouter des sons sur les jets",
   "SWFFG.EnableRollAudioHint": "Permettre aux utilisateurs d'ajouter des pistes audio à partir du dialogue de lancement",
   "SWFFG.EnableRollAudioPlaylist": "Roll - Playlist users use for roll audio",
   "SWFFG.EnableRollAudioPlaylistHint": "Il s'agit de la liste de lecture à laquelle les utilisateurs ont accès et à partir de laquelle ils peuvent ajouter de l'audio aux Jets.",
@@ -763,5 +763,7 @@
   "SWFFG.Settings.groupManager.Hint": "Configuration du gestionnaire de groupe",
   "SWFFG.Settings.groupManager.Label": "Configurer le gestionnaire de groupe",
   "SWFFG.Settings.actor.RivalTokenPrepend.Name": "Préfixer le nom des jetons de Rivaux",
-  "SWFFG.Settings.actor.RivalTokenPrepend.Hint": "Le nom des jetons de Rivaux non liés à un Acteur seront préfixé d'un adjectif. Exemple: \"Coléreux\""
+  "SWFFG.Settings.actor.RivalTokenPrepend.Hint": "Le nom des jetons de Rivaux non liés à un Acteur seront préfixé d'un adjectif. Exemple: \"Coléreux\"",
+  "SWFFG.Settings.dice.ApplyRemoveSetbackMods.Name": "Dés - Ajuster les dés d'Infortune",
+  "SWFFG.Settings.dice.ApplyRemoveSetbackMods.Hint": "Appliquer les modificateurs \"Retirer un dé d'Infortune\" automatiquement lorsque les dés sont jetés."
 }

--- a/modules/dice/pool.js
+++ b/modules/dice/pool.js
@@ -215,7 +215,19 @@ export class DicePoolFFG {
    * @returns {string} a dice expression that can be used to roll the dice pool
    */
   renderDiceExpression() {
-    let dicePool = [this.proficiency + "dp", this.ability + "da", this.challenge + "dc", this.difficulty + "di", this.boost + "db", this.setback + "ds", this.force + "df"];
+    let setbackDice = game.settings.get("starwarsffg", "ApplyRemoveSetbackMods")
+      ? Math.max(0, this.setback - this.remsetback)
+      : this.setback;
+
+    let dicePool = [
+      this.proficiency + "dp",
+      this.ability + "da",
+      this.challenge + "dc",
+      this.difficulty + "di",
+      this.boost + "db",
+      setbackDice + "ds",
+      this.force + "df",
+    ];
     let finalPool = dicePool.filter((d) => {
       const test = d.split(/([0-9]+)/);
       return test[1] > 0;

--- a/modules/helpers/dice-helpers.js
+++ b/modules/helpers/dice-helpers.js
@@ -42,8 +42,10 @@ export default class DiceHelpers {
       success: 0,
       triumph: 0,
       despair: 0,
+      remsetback: 0,
       upgrades: 0,
       label: skillData?.label ? game.i18n.localize(skillData.label) : game.i18n.localize(skillName),
+      source: {},
     };
     let characteristic = {
       value: 0,
@@ -106,6 +108,7 @@ export default class DiceHelpers {
       triumph: skill.triumph,
       despair: skill.despair,
       upgrades: skill.upgrades,
+      remsetback: skill?.remsetback ? skill.remsetback : 0,
       difficulty: 2 + status.difficulty, // default to average difficulty
     });
 
@@ -147,6 +150,7 @@ export default class DiceHelpers {
         triumph: skill?.triumph ? skill.triumph : 0,
         despair: skill?.despair ? skill.despair : 0,
         upgrades: skill?.upgrades ? skill.upgrades : 0,
+        remsetback: skill?.remsetback ? skill.remsetback : 0,
         source: {
           skill: skill?.ranksource?.length ? skill.ranksource : [],
           boost: skill?.boostsource?.length ? skill.boostsource : [],
@@ -158,7 +162,8 @@ export default class DiceHelpers {
           failure: skill?.failuresource?.length ? skill.failuresource : [],
           threat: skill?.threatsource?.length ? skill.threatsource : [],
           success: skill?.successsource?.length ? skill.successsource : [],
-          upgrades: skill?.upgradessource?.length ? skill.upgradessource: [],
+          remsetback: skill?.remsetbacksource.length ? skill.remsetbacksource : [],
+          upgrades: skill?.upgradessource?.length ? skill.upgradessource : [],
         },
       });
       dicePool.upgrade(Math.min(characteristic.value, skill.rank) + dicePool.upgrades);
@@ -195,6 +200,7 @@ export default class DiceHelpers {
       triumph: skill?.triumph ? skill.triumph : 0,
       despair: skill?.despair ? skill.despair : 0,
       upgrades: skill?.upgrades ? skill.upgrades : 0,
+      remsetback: skill?.remsetback ? skill.remsetback : 0,
       difficulty: 2 + status.difficulty, // default to average difficulty
     });
 
@@ -221,6 +227,7 @@ export default class DiceHelpers {
       success: skill.success,
       triumph: skill?.triumph ? skill.triumph : 0,
       despair: skill?.despair ? skill.despair : 0,
+      remsetback: skill?.remsetback ? skill.remsetback : 0,
       upgrades: skill?.upgrades ? skill.upgrades : 0,
     });
 
@@ -288,7 +295,7 @@ export function get_dice_pool(actor_id, skill_name, incoming_roll) {
   const characteristic = actor.system.characteristics[skill.characteristic];
 
   const dicePool = new DicePoolFFG({
-    ability: (Math.max(characteristic.value, skill.rank) + incoming_roll.ability) - (Math.min(characteristic.value, skill.rank) + incoming_roll.proficiency),
+    ability: Math.max(characteristic.value, skill.rank) + incoming_roll.ability - (Math.min(characteristic.value, skill.rank) + incoming_roll.proficiency),
     proficiency: Math.min(characteristic.value, skill.rank) + incoming_roll.proficiency,
     boost: skill.boost + incoming_roll.boost,
     setback: skill.setback + incoming_roll.setback,
@@ -302,7 +309,7 @@ export function get_dice_pool(actor_id, skill_name, incoming_roll) {
     triumph: skill.triumph + incoming_roll.triumph,
     despair: skill.despair + incoming_roll.despair,
     upgrades: skill.upgrades + incoming_roll.upgrades,
-    remsetback: skill.remsetback + incoming_roll.remsetback,
+    remsetback: skill?.remsetback ? skill.remsetback : 0 + incoming_roll.remsetback,
     difficulty: +incoming_roll.difficulty,
   });
   return dicePool;

--- a/modules/settings/settings-helpers.js
+++ b/modules/settings/settings-helpers.js
@@ -343,6 +343,7 @@ export default class SettingsHelpers {
       default: false,
       type: Boolean,
     });
+
   }
 
   // Initialize System Settings after the Ready Hook
@@ -375,6 +376,20 @@ export default class SettingsHelpers {
       choices: playlists,
     });
 
+    // Automatically apply "remove setback" modifiers when rolling
+    game.settings.register("starwarsffg", "ApplyRemoveSetbackMods", {
+      name: game.i18n.localize(
+        "SWFFG.Settings.dice.ApplyRemoveSetbackMods.Name"
+      ),
+      hint: game.i18n.localize(
+        "SWFFG.Settings.dice.ApplyRemoveSetbackMods.Hint"
+      ),
+      scope: "world",
+      config: true,
+      default: false,
+      type: Boolean,
+    });
+
     // Name default healing item
     game.settings.register("starwarsffg", "medItemName", {
       name: game.i18n.localize("SWFFG.MedicalItemName"),
@@ -387,14 +402,14 @@ export default class SettingsHelpers {
     });
 
     let stimpackChoices = [
-        game.i18n.localize("SWFFG.MedicalItemNameUsePrompt"),
-        game.i18n.localize("SWFFG.MedicalItemNameUseRest"),
-        game.i18n.localize("SWFFG.MedicalItemNameUseReset"),
+      game.i18n.localize("SWFFG.MedicalItemNameUsePrompt"),
+      game.i18n.localize("SWFFG.MedicalItemNameUseRest"),
+      game.i18n.localize("SWFFG.MedicalItemNameUseReset"),
     ];
     game.settings.register("starwarsffg", "HealingItemAction", {
       name: game.i18n.localize("SWFFG.MedicalItemSetting"),
       scope: "world",
-      default: '0',
+      default: "0",
       config: false,
       type: String,
       choices: stimpackChoices,


### PR DESCRIPTION
This PR should include removed setback dice icons in all roll windows, and actually remove setback dice when rolling the dice.

I've seen your answer on issue [#1719](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1719) and I'm wondering if it applies to my fix. Conditional "remove setback dice" bonus don't seem to be added as modifiers to the talent (at least when using oggdude's importer, e.g. Outdoorsman talent from Pathfinder spec), so any "remove setback dice" modifier present should apply to every roll of that skill.

Closes #1720 