### PR TITLE
fix(import): move from deprecated Document.createDocuments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
   * Remove Destiny Tracker hardcoded size, allowing it to grow and shrink when font size is changed ([#1688](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1688))
   * Assign correct modifiers type to armor: "armour" instead of "armor" ([#1697](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1697))
   * Skill purchases on actors now work via the dollar sign again ([#1713](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1713))
-  * Allows zero as a valid value when updating vehicle stats ([#1717](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1717))
+  * Allow zero as a valid value when updating vehicle stats ([#1717](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1717))
+  * Replace deprecated Document.createDocuments calls with Document() constructor ([#1683](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1683))
 
 `1.903`
 * Features:

--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -733,7 +733,7 @@ export class ActorSheetFFG extends ActorSheet {
                 default: CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER,
               }
             };
-            const tempItem = await Item.create(itemData, {temporary: true});
+            const tempItem = await new Item(itemData, { temporary: true });
             tempItem.sheet.render(true);
           } else {
             CONFIG.logger.debug(`Unknown item type: ${itemType}, or lacking new embed system`);

--- a/modules/helpers/embeddeditem-helpers.js
+++ b/modules/helpers/embeddeditem-helpers.js
@@ -199,7 +199,9 @@ export default class EmbeddedItemHelpers {
         },
       };
 
-      let readonlyItemJournalEntry = await JournalEntry.create(readonlyItem, {temporary: true});
+      let readonlyItemJournalEntry = await new JournalEntry(readonlyItem, {
+        temporary: true,
+      });
       readonlyItemJournalEntry.sheet.render(true)
     } catch (err) {
       ui.notifications.warn(`The item or quality has been removed or can not be found!`);
@@ -271,7 +273,7 @@ export default class EmbeddedItemHelpers {
 
     delete temp._id;
     delete temp.id;
-    let tempItem = await Item.create(temp, {temporary: true});
+    let tempItem = await new Item(temp, { temporary: true });
     tempItem.sheet.render(true);
   }
 
@@ -290,7 +292,7 @@ export default class EmbeddedItemHelpers {
       data,
     };
 
-    let tempItem = await Item.create(temp, {temporary: true});
+    let tempItem = await new Item(temp, { temporary: true });
 
     tempItem.data._id = temp.id;
     if (!temp.id) {

--- a/modules/importer/import-helpers.js
+++ b/modules/importer/import-helpers.js
@@ -2610,10 +2610,7 @@ export default class ImportHelpers {
               rank: modifier?.Count ? parseInt(modifier.Count, 10) : 1,
             },
           };
-          const descriptor = await Item.create(
-              unique,
-              { temporary: true }
-          );
+          const descriptor = await new Item(unique, { temporary: true });
           let rank = "";
           if (unique.system.rank > 1) {
             rank = `${game.i18n.localize("SWFFG.Count")} ${unique.system.rank}`;

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -58,7 +58,7 @@ export class ItemSheetFFG extends ItemSheet {
       );
     });
     // this is the end of the de-duplicating -=key stuff
-    
+
     data.data = data.item.system;
 
 
@@ -708,7 +708,7 @@ export class ItemSheetFFG extends ItemSheet {
       temp.ownership = {
         default: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
       }
-      let tempItem = await Item.create(temp, { temporary: true });
+      let tempItem = await new Item(temp, { temporary: true });
 
       tempItem.sheet.render(true);
     });
@@ -779,7 +779,7 @@ export class ItemSheetFFG extends ItemSheet {
         },
       };
 
-      let tempItem = await Item.create(temp, { temporary: true });
+      let tempItem = await new Item(temp, { temporary: true });
       CONFIG.logger.debug("Adding mod with the following data", tempItem);
 
       this.object.system[itemType].push(tempItem.toJSON());

--- a/modules/swffg-main.js
+++ b/modules/swffg-main.js
@@ -680,7 +680,7 @@ Hooks.on("renderChatMessage", async (app, html, messageData) => {
           default: CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER,
         }
       };
-      const tempItem = await Item.create(itemData, {temporary: true});
+      const tempItem = await new Item(itemData, {temporary: true});
       tempItem.sheet.render(true);
     } else {
       CONFIG.logger.debug(`Unknown item type: ${itemType}, or lacking new embed system`);
@@ -1015,7 +1015,7 @@ Hooks.once("ready", async () => {
         // abilities
         for(const abilityId of Object.keys(item.system.abilities)) {
           const abilityData = item.system.abilities[abilityId];
-          const abilityItem = await Item.create(
+          const abilityItem = await new Item(
             {
               name: abilityData.name,
               type: "ability",


### PR DESCRIPTION
This PR migrates the deprecated calls to `Document.createDocuments()` for temporary documents to the constructor `Document()` syntax.
Closes #1683