### PR TITLE
Issue 1731: Standard Rolling Dice Do Not Show Sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   * Allow zero as a valid value when updating vehicle stats ([#1717](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1717))
   * Replace deprecated Document.createDocuments calls with Document() constructor ([#1683](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1683))
   * Show removed setback dice icons and optionnally remove them from all rolls ([#1720](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1720))
+  * Problem with rolling of standard dice ([#1731](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1731))
 
 `1.903`
 * Features:

--- a/modules/dice/roll.js
+++ b/modules/dice/roll.js
@@ -142,7 +142,7 @@ export class RollFFG extends Roll {
       if (!game.ffg.diceterms.includes(term.constructor)) {
         if (term.evaluate) {
           if (!(term instanceof foundry.dice.terms.OperatorTerm)) this.hasStandard = true;
-          return await term.evaluate({ minimize, maximize }).total;
+          return await term.evaluate({ minimize, maximize }).then( result => result.total);
         } else return term;
       } else {
         if (term.evaluate) await term.evaluate({ minimize, maximize });
@@ -411,10 +411,10 @@ export class RollFFG extends Roll {
       })
       .flatMap((value, index, array) => {   //Put addition operators between each die, but not before or after another Operator
         if (array.length - 1 !== index && !(array[index] instanceof foundry.dice.terms.OperatorTerm) && !(array[index + 1] instanceof foundry.dice.terms.OperatorTerm)) {
-          return [value, new foundry.dice.terms.OperatorTerm({operator: '+'})] 
+          return [value, new foundry.dice.terms.OperatorTerm({operator: '+'})]
         } else {
           return value
         }
-      })          
+      })
   }
 }


### PR DESCRIPTION
In Step 3 of the ffg roll evaluate an array of promises is waited on. In the creation of this array  a value was being returned instead of a promise. I've updated the code to await the promise and its 'then' function

#1731 