### PR TITLE
Issue 1730 GM Destiny Rolls not counted

### DIFF
--- a/modules/ffg-destiny-tracker.js
+++ b/modules/ffg-destiny-tracker.js
@@ -260,7 +260,7 @@ export default class DestinyTracker extends FormApplication {
     }
 
     if (game.user.isGM) {
-      const roll = this._rollDestiny();
+      const roll = await this._rollDestiny();
 
       const light = await game.settings.get("starwarsffg", "dPoolLight");
       const dark = await game.settings.get("starwarsffg", "dPoolDark");


### PR DESCRIPTION
The async function _rollDestiny was not awaited in OnClickRollDesitny and this lead to a failure when a result was attempted to be used. This caused the actual roll to not be counted.

#1730 