### PR TITLE
Issue 1603 Use Defense when building dice pool does not work on itemRoll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   * Remove Destiny Tracker hardcoded size, allowing it to grow and shrink when font size is changed ([#1688](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1688))
   * Assign correct modifiers type to armor: "armour" instead of "armor" ([#1697](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1697))
   * Skill purchases on actors now work via the dollar sign again ([#1713](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1713))
+  * Use defense when building pool bug ([#1603](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1603))
   * Allow zero as a valid value when updating vehicle stats ([#1717](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1717))
   * Replace deprecated Document.createDocuments calls with Document() constructor ([#1683](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1683))
   * Show removed setback dice icons and optionnally remove them from all rolls ([#1720](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1720))

--- a/modules/helpers/dice-helpers.js
+++ b/modules/helpers/dice-helpers.js
@@ -75,22 +75,7 @@ export default class DiceHelpers {
     }
     const itemData = item || {};
     const status = this.getWeaponStatus(itemData);
-    let defenseDice = 0;
-    if (game.settings.get("starwarsffg", "useDefense")) {
-      let isRanged = ["Ranged: Light", "Ranged: Heavy", "Gunnery"].includes(skill.value);
-      let isMelee = ["Melee", "Brawl", "Lightsaber"].includes(skill.value);
-      if (itemData?.type === "weapon") {
-        if (game.user.targets.size > 0) {
-          for (const target of game.user.targets) {
-            if (isRanged) {
-              defenseDice = Math.max(defenseDice, target.actor.system.stats.defence.ranged);
-            } else if (isMelee) {
-              defenseDice = Math.max(defenseDice, target.actor.system.stats.defence.melee);
-            }
-          }
-        }
-      }
-    }
+    let defenseDice = this.getDefenseDice(skill, itemData);
 
     // TODO: Get weapon specific modifiers from itemmodifiers and itemattachments
 
@@ -122,6 +107,26 @@ export default class DiceHelpers {
 
     dicePool = new DicePoolFFG(await this.getModifiers(dicePool, itemData));
     await this.displayRollDialog(data, dicePool, `${game.i18n.localize("SWFFG.Rolling")} ${game.i18n.localize(skill.label)}`, skill.label, itemData, flavorText, sound);
+  }
+
+  static getDefenseDice(skill, itemData){
+    let defenseDice = 0;
+    if (game.settings.get("starwarsffg", "useDefense")) {
+      let isRanged = ["Ranged: Light", "Ranged: Heavy", "Gunnery"].includes(skill.value);
+      let isMelee = ["Melee", "Brawl", "Lightsaber"].includes(skill.value);
+      if (itemData?.type === "weapon" || itemData?.metaData?.tags?.includes("weapon")) {
+        if (game.user.targets.size > 0) {
+          for (const target of game.user.targets) {
+            if (isRanged) {
+              defenseDice = Math.max(defenseDice, target.actor.system.stats.defence.ranged);
+            } else if (isMelee) {
+              defenseDice = Math.max(defenseDice, target.actor.system.stats.defence.melee);
+            }
+          }
+        }
+      }
+    }
+    return defenseDice;
   }
 
   static async displayRollDialog(data, dicePool, description, skillName, item, flavorText, sound) {
@@ -185,11 +190,11 @@ export default class DiceHelpers {
 
     const skill = actor.system.skills[itemData.skill.value];
     const characteristic = actor.system.characteristics[skill.characteristic];
-
+    let defenseDice = this.getDefenseDice(skill, itemData);
     let dicePool = new DicePoolFFG({
       ability: Math.max(characteristic.value, skill.rank),
       boost: skill.boost,
-      setback: skill.setback + status.setback,
+      setback: skill.setback + status.setback + defenseDice,
       force: skill.force,
       advantage: skill.advantage,
       dark: skill.dark,


### PR DESCRIPTION
I made the logic to get defense die its own function and also made it check against item metadata to see if it has a weapon tag. I then added a call to this new function in the rollItem logic.

#1603 