### PR TITLE
#1909 added method to calculate base actor XP

### DIFF
--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -1086,7 +1086,7 @@ export class ItemSheetFFG extends ItemSheet {
       throw new Error("Refused to buy for item with no found owner actor");
     }
     const totalAvailableXp = owner.system.experience.available;
-    const totalSpentXp = owner.system.experience.total;
+    const totalXp = owner.system.experience.total;
     if (cost > totalAvailableXp) {
       ui.notifications.warn(game.i18n.localize("SWFFG.Actors.Sheets.Purchase.NotEnoughXP"));
       throw new Error("Not enough XP");
@@ -1096,7 +1096,7 @@ export class ItemSheetFFG extends ItemSheet {
       owner: owner,
       cost: cost,
       availableXP: baseAvailableXp,
-      totalXP: totalSpentXp,
+      totalXP: totalXp,
     }
   }
 


### PR DESCRIPTION
So the issue with #1909  was that when you adjust XP on an actor, it's effectively adding a modifier to the `system.experience.available` property. However, when the time  comes to purchase a specialization upgrade (or anything with XP), the method doesn't know that it's a modifier, it thinks the system.experience.available is the base available XP, and so when it calculates what the XP should be afterwards, it's setting baseXP to baseXP + modifiers. 

So, when you go back to the XP page for an actor, it now has effectively (baseXP + modifiers) + modifiers as the new XP. This will continue again and again for as long as you have the modifier. 

My fix is to have it so when you're calculating what XP is available for purchase, you undo all the active effects for the purposes of purchasing, but you don't actually remove them. It uses the total available XP to determine whether you **can** purchase something, but uses the base XP to actually make the purchase, so when you return to the actor page, it still applies the active effect and it makes it look like the XP has been properly deducted. 

