### PR TITLE
refactor(actor): debounce sheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   * Vehicle sheets no longer break when a crew member has been deleted ([#1959](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1959))
   * Force Dice Boost now accounts for the full Force Rating ([#1949](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1949))
   * OggDude data imports now default to deleting existing compendiums (most updated import logic relies on the compendiums not existing) ([#1964](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1964))
+  * Actor sheets should no longer go wild when manually adjusting XP ([#1954](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1954))
+  * Fixed a strange bug where XP would sometimes plummet to -20 and total would become null
 
 `1.909`
 * Features:

--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -2434,11 +2434,11 @@ export class ActorSheetFFG extends ActorSheet {
           label: game.i18n.localize("SWFFG.XP.Adjust.Confirm"),
           callback: async () => {
             const availableXPToLog = foundry.utils.deepClone(parseInt(this.actor.system.experience.available));
-            const AEState = await ActorHelpers.beginEditMode(this.actor, true);
-            const startingAvailableXP =  parseInt(this.actor.system.experience.available);
-            const totalXP =  parseInt(this.actor.system.experience.total);
             const adjustAmount = parseInt($("#adjustAmount").val());
-            const adjustReason = $("#adjustReason").val();
+            const adjustReason = foundry.utils.deepClone($("#adjustReason").val());
+            const AEState = await ActorHelpers.beginEditMode(this.actor, true);
+            const startingAvailableXP =  foundry.utils.deepClone(parseInt(this.actor.system.experience.available));
+            const totalXP =  foundry.utils.deepClone(parseInt(this.actor.system.experience.total));
             const updatedAvailableXP = startingAvailableXP + adjustAmount;
             const updatedTotalXP = totalXP + adjustAmount;
             await this.actor.update({ 'system.experience.available': updatedAvailableXP, 'system.experience.total': updatedTotalXP });
@@ -2451,7 +2451,6 @@ export class ActorSheetFFG extends ActorSheet {
               "Self"
             );
             await ActorHelpers.endEditMode(this.actor, AEState, true);
-            await this.render(true);
          }
       },
       two: {
@@ -2461,6 +2460,22 @@ export class ActorSheetFFG extends ActorSheet {
      },
     });
     d.render(true);
+  }
+
+  debounceRender = foundry.utils.debounce(
+    (force, options) => {
+      super.render(force, options);
+    },
+    100,
+    {
+      leading: true,
+      maxWait: 100,
+    },
+  );
+
+  /** @override **/
+  render(force, options) {
+    this.debounceRender(force, options);
   }
 }
 


### PR DESCRIPTION
* add debouncing for manually adjusting XP on actor sheets
* fix a bug on slow connections where the available XP would become -20 and total would become null (I hope)

#1954