### PR TITLE
Limit callbacks execution to originating user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+`1.911`
+* Fixes:
+  * Fix species talents/abilities being added/removed by each player online leading to duplicates if GM is online. ([#1832](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1832))
+
 `1.910`
 * Fixes:
   * Correct XP manual adjustment bug ([#1948](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1948))

--- a/modules/swffg-main.js
+++ b/modules/swffg-main.js
@@ -1230,6 +1230,7 @@ Hooks.once("ready", async () => {
   });
 
   Hooks.on("createItem", async (item, options, userId) => {
+    if (userId != game.user.id) return
     // add talents from species to character
     if (item.isEmbedded && item.parent.documentName === "Actor") {
       const actor = item.actor
@@ -1272,6 +1273,7 @@ Hooks.once("ready", async () => {
   });
   // data for _onDropItemCreate has system.encumbrance.adjusted = 0, despite it being proper in the item itself
   Hooks.on("deleteItem", (item, options, userId) => {
+    if (userId != game.user.id) return
     // remove talents added by species
     if (item.isEmbedded && item.parent.documentName === "Actor") {
       const actor = item.actor


### PR DESCRIPTION
Currently when one of players/GMs adds species to character list (or removes it), callback is called on each client online to add species' talents, so if player creates characters and there is GM online - player's character would receive twice as much talents (and can't delete duplicates, as they are fromSpecies=true). Deleting species deletes only one of each talent, so adding-deleting Droid to character leaaves you with character list with Enduring which can't be removed (possibly it is better to delete each fromSpecies=true items instead). Also each other player tries to do the same modification and gets 'no permission to modify' error or 'item does not exist'.