### PR TITLE
Blocking AEs to affect stats when in editing mode

### DIFF
--- a/modules/actors/actor-ffg.js
+++ b/modules/actors/actor-ffg.js
@@ -685,23 +685,27 @@ export class ActorFFG extends Actor {
 
   /** @override **/
   applyActiveEffects() {
-    // collect force pool modifications since it appears the stat value is without AEs active
-    let maxForceRating = parseInt(this.system?.stats?.forcePool?.max);
-    for (const effect of this.allApplicableEffects()) {
-      for (const change of effect.changes) {
-        if (change.key === "system.stats.forcePool.max") {
-          maxForceRating += parseInt(change.value);
+    // While in editing mode, we don't want our AEs from items, talents, etc to mess up with the stats
+    if(!this.flags.starwarsffg.config.enableEditMode)
+    {
+      // collect force pool modifications since it appears the stat value is without AEs active
+      let maxForceRating = parseInt(this.system?.stats?.forcePool?.max);
+      for (const effect of this.allApplicableEffects()) {
+        for (const change of effect.changes) {
+          if (change.key === "system.stats.forcePool.max") {
+            maxForceRating += parseInt(change.value);
+          }
         }
       }
-    }
-    // apply the resulting value (minus any committed dice)
-    for (const effect of this.allApplicableEffects()) {
-      for (const change of effect.changes) {
-        if (change.key.includes("system.skills") && change.key.includes(".force")) {
-          change.value = Math.max(maxForceRating - parseInt(this.system?.stats?.forcePool?.value), 0);
+      // apply the resulting value (minus any committed dice)
+      for (const effect of this.allApplicableEffects()) {
+        for (const change of effect.changes) {
+          if (change.key.includes("system.skills") && change.key.includes(".force")) {
+            change.value = Math.max(maxForceRating - parseInt(this.system?.stats?.forcePool?.value), 0);
+          }
         }
       }
+      return super.applyActiveEffects();
     }
-    return super.applyActiveEffects();
   }
 }


### PR DESCRIPTION
As per issue #1976 active effects were affecting stats when changing basic attributes or any other stat while in editing mode. The problem is that they stack up and never reset. To prevent this I block AEs to affect stats while in editing mode