### PR TITLE
Fix universal specs cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   * Fix for editing specialization top description not showing current text ([#2041](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2041))
   * the OggDude Dataset importer now uses custom default images if images are not provided ([#2044](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2044))
   * Removed the `Stat All` modifier option, which was a union of `Stat`, `Weapon Stat`, `Vehicle Stat`, and `Amor Stat` ([#1986](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1986))
+  * Fix universal specializations costing more XP when purchased via drag-and-drop ([2057](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2057))
 
 `1.910`
 * Fixes:

--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -171,7 +171,7 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
         }
         const specializationCount = (this.actor.items.filter(i => i.type === "specialization") || []).length;
         cost = (specializationCount + 1) * 10;
-        if (!inCareer) {
+        if (!inCareer && !itemData.system.universal) {
           cost += 10;
         }
         return cost;


### PR DESCRIPTION
Fixes #2057: Universal specializations costing +10 XP when purchased via drag-and-drop.