### PR TITLE
Fix pause icon setting not being applied

### DIFF
--- a/modules/swffg-main.js
+++ b/modules/swffg-main.js
@@ -1610,11 +1610,9 @@ Hooks.once("diceSoNiceReady", (dice3d) => {
 });
 
 Hooks.on("renderGamePause", function (_application, element, _context, _options) {
-  if (game.data.paused) {
-    const pausedImage = game.settings.get("starwarsffg", "ui-pausedImage");
-    if (pausedImage) {
-      element.querySelector("img").src = pausedImage;
-    }
+  const pausedImage = game.settings.get("starwarsffg", "ui-pausedImage");
+  if (pausedImage) {
+    element.querySelector("img").src = pausedImage;
   }
 });
 


### PR DESCRIPTION
Fixes the pause icon setting for v13 (#2063). No CHANGELOG update because it's just preventing a regression.