### PR TITLE
fix(transfer): token-to-actor transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
   * the OggDude Dataset importer now uses custom default images if images are not provided ([#2044](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2044))
   * Removed the `Stat All` modifier option, which was a union of `Stat`, `Weapon Stat`, `Vehicle Stat`, and `Amor Stat` ([#1986](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1986))
   * Fix universal specializations costing more XP when purchased via drag-and-drop ([2057](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2057))
+  * Moving items from a token to an actor will no longer remove the item from the parent actor of the token ([#2067](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2067))
 
 `1.910`
 * Fixes:

--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -1994,6 +1994,15 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
       if (!sameActor) {
         try {
           this.actor.createEmbeddedDocuments("Item", [foundry.utils.duplicate(data.data)]); // Create a new Item
+          let token;
+          if (game.scenes.current) {
+            token = game.scenes.current.tokens.get(data?.tokenId);
+            if (token) {
+              // Delete originating item from other _token_
+              token.actor.items.get(data.data._id)?.delete();
+              return;
+            }
+          }
           const actor = game.actors.get(data.actorId);
           await actor.items.get(data.data._id)?.delete(); // Delete originating item from other actor
         } catch (err) {


### PR DESCRIPTION
* fixes items being deleted from the parent actor when items are moved from a token to another actor

#2067