### PR TITLE
fix(xp): fp upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
   * Removed the `Stat All` modifier option, which was a union of `Stat`, `Weapon Stat`, `Vehicle Stat`, and `Amor Stat` ([#1986](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/1986))
   * Fix universal specializations costing more XP when purchased via drag-and-drop ([2057](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2057))
   * Moving items from a token to an actor will no longer remove the item from the parent actor of the token ([#2067](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2067))
+  * Fix for Force Power upgrades sometimes being purchasable despite not having enough XP ([#2074](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2074))
 
 `1.910`
 * Fixes:

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -1117,13 +1117,13 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
       throw new Error("Refused to buy for item with no found owner actor");
     }
     const availableXPToLog = foundry.utils.deepClone(owner.system.experience.available);
-    const AEState = await ActorHelpers.beginEditMode(owner, true);
     const availableXP = owner.system.experience.available;
     const totalXP = owner.system.experience.total;
     if (cost > availableXP) {
       ui.notifications.warn(game.i18n.localize("SWFFG.Actors.Sheets.Purchase.NotEnoughXP"));
       throw new Error("Not enough XP");
     }
+    const AEState = await ActorHelpers.beginEditMode(owner, true);
     return {
       owner: owner,
       cost: cost,


### PR DESCRIPTION
* moves beginning edit mode to the end of purchasing, removing a race condition which sometimes allowed purchasing items without enough XP

#2074