### PR TITLE
Fix for the .enableDebug setting not found in modules

### DIFF
--- a/modules/settings/settings-helpers.js
+++ b/modules/settings/settings-helpers.js
@@ -218,17 +218,6 @@ export default class SettingsHelpers {
       },
     });
 
-    // Enable debug messages in console
-    game.settings.register("starwarsffg", "enableDebug", {
-      name: game.i18n.localize("SWFFG.EnableDebug"),
-      hint: game.i18n.localize("SWFFG.EnableDebugHint"),
-      scope: "world",
-      config: true,
-      default: false,
-      type: Boolean,
-      onChange: this.debouncedReload,
-    });
-
     // Register settings for UI Themes
     game.settings.register("starwarsffg", "ui-uitheme", {
       module: "starwarsffg",

--- a/modules/swffg-main.js
+++ b/modules/swffg-main.js
@@ -129,6 +129,17 @@ Hooks.once("init", async function () {
   CONFIG.ui.pause = PauseFFG;
 
 
+  // Enable debug messages in console
+  game.settings.register("starwarsffg", "enableDebug", {
+    name: game.i18n.localize("SWFFG.EnableDebug"),
+    hint: game.i18n.localize("SWFFG.EnableDebugHint"),
+    scope: "world",
+    config: true,
+    default: false,
+    type: Boolean,
+    onChange: this.debouncedReload,
+  });
+
    /**
    * Register statuses to add
    */


### PR DESCRIPTION
While tinkering with the Enhancements module I noticed that it requires .enableDebug option to be instantiated first. Moving it to the very front of the system initiation to make it hook properly