### PR TITLE
fix(AEs): talents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * "Rival" and "Nemesis" default images are now swapped (to their appropriate setting!)
   * The PC Wizard no longer spams a trillion temporary actors ([#2183](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2183))
   * The PC Wizard now properly sets starting/total XP and generates entries in the XP log ([#2178](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2178))
+  * Fix for Talents granting their modifier when dropped onto a Specialization regardless of learned status ([#2203](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2203))
 
 `2.0.2`
 * Fixes:

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -1998,8 +1998,8 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
         toCreate.push(activeEffect);
       }
       CONFIG.logger.debug(toCreate);
-      await this.object.createEmbeddedDocuments("ActiveEffect", toCreate);
-      await ItemHelpers.syncAEStatus(this.object, toCreate);
+      const createdEffects = await this.object.createEmbeddedDocuments("ActiveEffect", toCreate);
+      await ItemHelpers.syncAEStatus(this.object, createdEffects);
     } else {
       CONFIG.logger.debug(`Rejected transferring AEs for drag-and-drop of ${droppedType} -> ${myType}`);
     }


### PR DESCRIPTION
* sync status of AE on dropped item, not parent item

#2203