### PR TITLE
fix(importer): talents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+`2.0.4`
+* Fixes:
+  * Fix for long description of talents importing from oggdude data as empty - long descriptions are now filled with same data as short description ([#2231](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2231))
+  
 `2.0.3`
 * Enhancements:
   * Strain, Hull Trauma, and System Strain can now be set above the threshold on tokens ([#2177](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2177))

--- a/modules/importer/oggdude/importers/talents.js
+++ b/modules/importer/oggdude/importers/talents.js
@@ -61,7 +61,7 @@ export default class Talents {
             data.data = {
               attributes: {},
               description: item.Description,
-              longDesc: "",
+              longDesc: item.Description,
               ranks: {
                 ranked: item.Ranked === "true" ? true : false,
               },


### PR DESCRIPTION
* importer - item.description to long description of talents. This allows for send to chat to display the description.
Fixes issue for #2231 