### PR TITLE
Fix(importer): Fixing bugs in the importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,4 @@
 `2.0.4`
-* Fixes:
-  * Fixed some issues with the importrt code, [@KamiliaBlow](https://github.com/KamiliaBlow))
-    * Fixed a formatting error during import that caused the description block for careers to be empty
-    * Fixed an import issue that could corrupt the entire dataset import when modifying Skills.xml; this occurred if the ```<Name>``` element contained a translation into another language. ([#2170](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2170))
-    * Fixed a bug in the Specializations import feature that did not account for the presence of tags has been fixed. Now, if a user wants to add tags to Specializations, the system will correctly read them from the Specializations file
-    * The import of sources has been updated; these sources could be of the following types: ```<Source>User Data</Source>``` and ```<Source/> <Source/>```. ([#2268](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2268))
 * Features:
   * Added a compendium browser to search and filter items across all world compendiums! ([#2267](https://github.com/StarWarsFoundryVTT/StarWarsFFG/pull/2267), [@KamiliaBlow](https://github.com/KamiliaBlow))
     * Accessible via a button in the compendiums directory for all users (not just GMs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 `2.0.4`
+* Fixes:
+  * Fixed some issues with the importer code, [@KamiliaBlow](https://github.com/KamiliaBlow))
+    * Fixed a formatting error during import that caused the description block for careers to be empty
+    * Fixed an import issue that could corrupt the entire dataset import when modifying Skills.xml; this occurred if the ```<Name>``` element contained a translation into another language. ([#2170](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2170))
+    * Fixed a bug in the Specializations import feature that did not account for the presence of tags has been fixed. Now, if a user wants to add tags to Specializations, the system will correctly read them from the Specializations file
+    * The import of sources has been updated; these sources could be of the following types: ```<Source>User Data</Source>``` and ```<Source/> <Source/>```. ([#2268](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2268))
 * Features:
   * Added a compendium browser to search and filter items across all world compendiums! ([#2267](https://github.com/StarWarsFoundryVTT/StarWarsFFG/pull/2267), [@KamiliaBlow](https://github.com/KamiliaBlow))
     * Accessible via a button in the compendiums directory for all users (not just GMs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 `2.0.4`
+* Fixes:
+  * Fixed some issues with the importrt code, [@KamiliaBlow](https://github.com/KamiliaBlow))
+    * Fixed a formatting error during import that caused the description block for careers to be empty
+    * Fixed an import issue that could corrupt the entire dataset import when modifying Skills.xml; this occurred if the ```<Name>``` element contained a translation into another language. ([#2170](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2170))
+    * Fixed a bug in the Specializations import feature that did not account for the presence of tags has been fixed. Now, if a user wants to add tags to Specializations, the system will correctly read them from the Specializations file
+    * The import of sources has been updated; these sources could be of the following types: ```<Source>User Data</Source>``` and ```<Source/> <Source/>```. ([#2268](https://github.com/StarWarsFoundryVTT/StarWarsFFG/issues/2268))
 * Features:
   * Added a compendium browser to search and filter items across all world compendiums! ([#2267](https://github.com/StarWarsFoundryVTT/StarWarsFFG/pull/2267), [@KamiliaBlow](https://github.com/KamiliaBlow))
     * Accessible via a button in the compendiums directory for all users (not just GMs)

--- a/modules/importer/data-importer.js
+++ b/modules/importer/data-importer.js
@@ -203,7 +203,7 @@ export default class DataImporter extends HandlebarsApplicationMixin(Application
         for (const doc of skillDocs) {
           const importId = doc.flags?.starwarsffg?.ffgimportid;
           if (importId) {
-            CONFIG.temporary.skills[importId] = doc.name;
+            CONFIG.temporary.skills[importId] = ImportHelpers.oggSkillKeyToSystemKey(importId) ?? doc.name;
           }
         }
         this._importLogger(`Loaded ${Object.keys(CONFIG.temporary.skills).length} skills from world compendium`);

--- a/modules/importer/import-helpers.js
+++ b/modules/importer/import-helpers.js
@@ -2305,6 +2305,29 @@ export default class ImportHelpers {
       .replace(/\[P\]/g, "");
   }
 
+  static _skillKeyToName = null;
+
+  /**
+   * Resolves an OggDude skill Key to the system's stable skill key (the English
+   * name used as the key in CONFIG.FFG.skills), derived from the skill
+   * templates so it is independent of the translatable <Name> in Skills.xml.
+   * @param {string} oggKey - OggDude skill Key (e.g. "ASTRO").
+   * @returns {string|undefined} System skill key (e.g. "Astrogation"), or
+   *   undefined if the Key is not a recognised built-in skill.
+   */
+  static oggSkillKeyToSystemKey(oggKey) {
+    if (ImportHelpers._skillKeyToName === null) {
+      ImportHelpers._skillKeyToName = {};
+      for (const template of [ImportHelpers.minionTemplate, ImportHelpers.characterTemplate]) {
+        const skills = template?.data?.skills ?? {};
+        for (const [name, def] of Object.entries(skills)) {
+          if (def?.Key) ImportHelpers._skillKeyToName[def.Key] ??= name;
+        }
+      }
+    }
+    return ImportHelpers._skillKeyToName[oggKey];
+  }
+
   static prepareBaseObject(obj, type) {
     return {
       name: obj.Name,

--- a/modules/importer/import-helpers.js
+++ b/modules/importer/import-helpers.js
@@ -2213,34 +2213,40 @@ export default class ImportHelpers {
    * @returns {*[]}
    */
   static getSourcesAsArray(sources) {
-    let parsedSources = [];
+    const parsedSources = [];
 
     // if there are no sources, don't bother trying to parse
     if (!sources) {
       return parsedSources;
     }
 
-    // sometimes there's a single source not inside a `source` block
-    if (sources?._) {
-      sources.Source = [sources];
+    // normalize into an array of source entries
+    let arr;
+    if (Array.isArray(sources)) {
+      // multiple <Source> siblings without a <Sources> wrapper
+      arr = sources;
+    } else if (typeof sources === "string") {
+      // <Source>User Data</Source> (no attributes)
+      arr = [{ _: sources }];
+    } else if (sources.Source !== undefined) {
+      // <Sources><Source/>...</Sources> wrapper
+      arr = Array.isArray(sources.Source) ? sources.Source : [sources.Source];
+    } else {
+      // single <Source Page="x">text</Source>
+      arr = [sources];
     }
 
-    try {
-      // convert the sources to an array if they aren't already one (silly XML)
-      if (!Array.isArray(sources.Source)) {
-        sources.Source = [sources.Source];
+    for (const source of arr) {
+      if (source == null) {
+        continue;
       }
-
-      for (const source of sources.Source) {
-        if (source?.$Page) {
-          parsedSources.push(`${source._} pg.${source.$Page}`);
-        } else {
-          parsedSources.push(source._);
-        }
+      if (typeof source === "string") {
+        parsedSources.push(source);
+      } else if (source.$Page != null) {
+        parsedSources.push(`${source._} pg.${source.$Page}`);
+      } else if (source._ != null) {
+        parsedSources.push(source._);
       }
-    } catch {
-      // in all the cases I looked at, this is due to bad data. just return what we've got so far
-      return parsedSources;
     }
     return parsedSources;
   }

--- a/modules/importer/import-helpers.js
+++ b/modules/importer/import-helpers.js
@@ -2277,6 +2277,34 @@ export default class ImportHelpers {
     return sourceText;
   }
 
+  /**
+   * Cleans an OggDude item description for storage. Normalises line endings,
+   * drops a leading [H4]Name[h4] duplicate of the item name, and converts
+   * OggDude markup tokens ([H4], [B], [P], ...) to HTML.
+   * @param {string} description - Raw description text from the dataset.
+   * @returns {string} Cleaned HTML description.
+   */
+  static cleanDescription(description) {
+    const text = (description || "").replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
+    const lines = text.split("\n");
+    if (lines.length && lines[0].includes("[H4]")) {
+      lines.shift();
+    }
+    return lines
+      .join("<br>")
+      .replace(/^(<br>)+/, "")
+      .replace(/\[H4\]/g, "<h4>")
+      .replace(/\[h4\]/g, "</h4>")
+      .replace(/\[H3\]/g, "<h3>")
+      .replace(/\[h3\]/g, "</h3>")
+      .replace(/\[B\]/g, "<b>")
+      .replace(/\[b\]/g, "</b>")
+      .replace(/\[I\]/g, "<i>")
+      .replace(/\[i\]/g, "</i>")
+      .replace(/\[BR\]/g, "<br>")
+      .replace(/\[P\]/g, "");
+  }
+
   static prepareBaseObject(obj, type) {
     return {
       name: obj.Name,

--- a/modules/importer/oggdude/importers/armor.js
+++ b/modules/importer/oggdude/importers/armor.js
@@ -28,10 +28,7 @@ export default class Armor {
           try {
             let data = ImportHelpers.prepareBaseObject(item, "armour");
 
-            if (item.Description.split('\n').length > 0 && item.Description.includes('[H4]')) {
-              // remove the item name in the description....
-              item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-            }
+            item.Description = ImportHelpers.cleanDescription(item.Description);
 
             data.data = {
               attributes: {},

--- a/modules/importer/oggdude/importers/backgrounds.js
+++ b/modules/importer/oggdude/importers/backgrounds.js
@@ -46,10 +46,7 @@ export default class Backgrounds {
         await ImportHelpers.asyncForEach(items, async (item) => {
           let data = ImportHelpers.prepareBaseObject(item, "background");
 
-          if (item.Description.split('\n').length > 0 && item.Description.includes('[H4]')) {
-            // remove the item name in the description....
-            item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-          }
+          item.Description = ImportHelpers.cleanDescription(item.Description);
 
           data.data = {
             type: backgroundType,

--- a/modules/importer/oggdude/importers/careers.js
+++ b/modules/importer/oggdude/importers/careers.js
@@ -35,14 +35,7 @@ export default class Career {
 
             let data = ImportHelpers.prepareBaseObject(item, "career");
 
-            if (item.Description.split('\n').length > 0) {
-              item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-            }
-
-            if (item.Description.split('\n').length > 0 && item.Description.includes('[H4]')) {
-              // remove the item name in the description....
-              item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-            }
+            item.Description = ImportHelpers.cleanDescription(item.Description);
 
             data.data = {
               attributes: {},

--- a/modules/importer/oggdude/importers/forcepowers.js
+++ b/modules/importer/oggdude/importers/forcepowers.js
@@ -45,15 +45,10 @@ export default class ForcePowers {
               return ability.Key === basePowerKey;
             });
 
-            if (item.Description.split('\n').length > 0 && item.Description.includes('[H4]')) {
-              // remove the item name in the description....
-              item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-            }
-
             let data = ImportHelpers.prepareBaseObject(item, "forcepower");
             data.data = {
               attributes: {},
-              description: basepower.Description,
+              description: ImportHelpers.cleanDescription(basepower.Description),
               upgrades: {},
               required_force_rating: item?.MinForceRating ? item.MinForceRating : 1,
               metadata: {

--- a/modules/importer/oggdude/importers/forcepowers.js
+++ b/modules/importer/oggdude/importers/forcepowers.js
@@ -45,10 +45,12 @@ export default class ForcePowers {
               return ability.Key === basePowerKey;
             });
 
+            basepower.Description = ImportHelpers.cleanDescription(basepower.Description);
+
             let data = ImportHelpers.prepareBaseObject(item, "forcepower");
             data.data = {
               attributes: {},
-              description: ImportHelpers.cleanDescription(basepower.Description),
+              description: basepower.Description,
               upgrades: {},
               required_force_rating: item?.MinForceRating ? item.MinForceRating : 1,
               metadata: {

--- a/modules/importer/oggdude/importers/gear.js
+++ b/modules/importer/oggdude/importers/gear.js
@@ -28,9 +28,7 @@ export default class Gear {
           try {
             let data = ImportHelpers.prepareBaseObject(item, "gear");
 
-            if (item.Description.split('\n').length > 0) {
-              item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-            }
+            item.Description = ImportHelpers.cleanDescription(item.Description);
 
             data.data = {
               attributes: {},

--- a/modules/importer/oggdude/importers/item-attachments.js
+++ b/modules/importer/oggdude/importers/item-attachments.js
@@ -41,9 +41,7 @@ export default class ItemAttachments {
             data = ImportHelpers.prepareBaseObject(item, "itemattachment");
           }
 
-          if (item.Description.split('\n').length > 0) {
-            item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-          }
+          item.Description = ImportHelpers.cleanDescription(item.Description);
 
           data.img = `/systems/starwarsffg/images/mod-${item?.Type ? item.Type.toLowerCase() : "all"}.png`;
           data.data = {

--- a/modules/importer/oggdude/importers/item-descriptors.js
+++ b/modules/importer/oggdude/importers/item-descriptors.js
@@ -38,9 +38,12 @@ export default class ItemDescriptors {
         } else {
           data = ImportHelpers.prepareBaseObject(item, "itemmodifier");
         }
+
+        item.Description = ImportHelpers.cleanDescription(item.Description?.length ? item.Description : item.ModDesc);
+
         data.img = `/systems/starwarsffg/images/mod-${item.Type ? item.Type.toLowerCase() : "all"}.png`;
         data.data = {
-          description: ImportHelpers.cleanDescription(item.Description?.length ? item.Description : item.ModDesc),
+          description: item.Description,
           attributes: {},
           type: item.Type ? item.Type.toLowerCase() : "all",
           rank: 1,

--- a/modules/importer/oggdude/importers/item-descriptors.js
+++ b/modules/importer/oggdude/importers/item-descriptors.js
@@ -40,7 +40,7 @@ export default class ItemDescriptors {
         }
         data.img = `/systems/starwarsffg/images/mod-${item.Type ? item.Type.toLowerCase() : "all"}.png`;
         data.data = {
-          description: item.Description?.length ? item.Description : item.ModDesc,
+          description: ImportHelpers.cleanDescription(item.Description?.length ? item.Description : item.ModDesc),
           attributes: {},
           type: item.Type ? item.Type.toLowerCase() : "all",
           rank: 1,

--- a/modules/importer/oggdude/importers/motivations.js
+++ b/modules/importer/oggdude/importers/motivations.js
@@ -30,10 +30,7 @@ export default class Motivations {
         await ImportHelpers.asyncForEach(items, async (item) => {
           let data = ImportHelpers.prepareBaseObject(item, "motivation");
 
-          if (item.Description.split('\n').length > 0 && item.Description.includes('[H4]')) {
-            // remove the item name in the description....
-            item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-          }
+          item.Description = ImportHelpers.cleanDescription(item.Description);
 
           data.data = {
             type: CONFIG.FFG.characterCreator.motivationTypes[item.Motivation].value,

--- a/modules/importer/oggdude/importers/obligation.js
+++ b/modules/importer/oggdude/importers/obligation.js
@@ -50,10 +50,7 @@ export default class Obligation {
         await ImportHelpers.asyncForEach(items, async (item) => {
           let data = ImportHelpers.prepareBaseObject(item, "obligation");
 
-          if (item.Description.split('\n').length > 0 && item.Description.includes('[H4]')) {
-            // remove the item name in the description....
-            item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-          }
+          item.Description = ImportHelpers.cleanDescription(item.Description);
 
           data.data = {
             type: motivationType,

--- a/modules/importer/oggdude/importers/signature-abilities.js
+++ b/modules/importer/oggdude/importers/signature-abilities.js
@@ -38,10 +38,7 @@ export default class SignatureAbilities {
 
           let data = ImportHelpers.prepareBaseObject(item, "signatureability");
 
-          if (item.Description.split('\n').length > 0 && item.Description.includes('[H4]')) {
-            // remove the item name in the description....
-            item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-          }
+          item.Description = ImportHelpers.cleanDescription(item.Description);
 
           data.data = {
             description: item.Description,

--- a/modules/importer/oggdude/importers/skills.js
+++ b/modules/importer/oggdude/importers/skills.js
@@ -47,7 +47,8 @@ export default class Skills {
             },
           }],
         };
-        CONFIG.temporary.skills[data.flags.starwarsffg.ffgimportid] = data.name;
+        const skillId = data.flags.starwarsffg.ffgimportid;
+        CONFIG.temporary.skills[skillId] = ImportHelpers.oggSkillKeyToSystemKey(skillId) ?? data.name;
 
         if (createJournalCompendium) {
           switch (item.TypeValue) {

--- a/modules/importer/oggdude/importers/skills.js
+++ b/modules/importer/oggdude/importers/skills.js
@@ -29,9 +29,7 @@ export default class Skills {
 
     await ImportHelpers.asyncForEach(items, async (item) => {
       try {
-        if (item.Description.split('\n').length > 0) {
-          item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-        }
+        item.Description = ImportHelpers.cleanDescription(item.Description);
 
         let data = {
           name: `${item.TypeValue === "stKnowledge" ? "Knowledge: " : ""}${item.Name.replace(" - ", ": ")}`,

--- a/modules/importer/oggdude/importers/specializations.js
+++ b/modules/importer/oggdude/importers/specializations.js
@@ -33,10 +33,7 @@ export default class Specializations {
             const specializationData = JXON.xmlToJs(xmlData);
             const item = specializationData.Specialization;
 
-            if (item.Description.split('\n').length > 0 && item.Description.includes('[H4]')) {
-              // remove the item name in the description....
-              item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-            }
+            item.Description = ImportHelpers.cleanDescription(item.Description);
 
             let data = ImportHelpers.prepareBaseObject(item, "specialization");
             data.system = {

--- a/modules/importer/oggdude/importers/specializations.js
+++ b/modules/importer/oggdude/importers/specializations.js
@@ -128,17 +128,17 @@ export default class Specializations {
             try {
               if (Array.isArray(item.Categories.Category)) {
                 for (const tag of item.Categories.Category) {
-                  data.data.metadata.tags.push(tag.toLowerCase());
+                  data.system.metadata.tags.push(tag.toLowerCase());
                 }
               } else {
-                data.data.metadata.tags.push(item.Categories.Category.toLowerCase());
+                data.system.metadata.tags.push(item.Categories.Category.toLowerCase());
               }
             } catch (err) {
               CONFIG.logger.debug(`No categories found for item ${item.Key}`);
             }
             if (item?.Type) {
               // the "type" can be useful as a tag as well
-              data.data.metadata.tags.push(item.Type.toLowerCase());
+              data.system.metadata.tags.push(item.Type.toLowerCase());
             }
 
             let imgPath = await ImportHelpers.getImageFilename(zip, "Specialization", "", data.flags.starwarsffg.ffgimportid);

--- a/modules/importer/oggdude/importers/species.js
+++ b/modules/importer/oggdude/importers/species.js
@@ -33,10 +33,7 @@ export default class Species {
             const speciesData = JXON.xmlToJs(xmlData);
             const item = speciesData.Species;
 
-            if (item.Description.split('\n').length > 0 && item.Description.includes('[H4]')) {
-              // remove the item name in the description....
-              item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-            }
+            item.Description = ImportHelpers.cleanDescription(item.Description);
 
             let data = ImportHelpers.prepareBaseObject(item, "species");
 

--- a/modules/importer/oggdude/importers/talents.js
+++ b/modules/importer/oggdude/importers/talents.js
@@ -53,10 +53,7 @@ export default class Talents {
                 activationLabel = "SWFFG.TalentActivationsPassive";
             }
 
-            if (item.Description.split('\n').length > 0 && item.Description.includes('[H4]')) {
-              // remove the item name in the description....
-              item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-            }
+            item.Description = ImportHelpers.cleanDescription(item.Description);
 
             data.data = {
               attributes: {},

--- a/modules/importer/oggdude/importers/vehicles.js
+++ b/modules/importer/oggdude/importers/vehicles.js
@@ -36,9 +36,7 @@ export default class Vehicles {
 
             const pack = isSpaceVehicle ? await ImportHelpers.getCompendiumPack("Actor", `oggdude.Vehicles.Space`) : await ImportHelpers.getCompendiumPack("Actor", `oggdude.Vehicles.Planetary`);
 
-            if (item.Description.split('\n').length > 0) {
-              item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-            }
+            item.Description = ImportHelpers.cleanDescription(item.Description);
 
             let data = ImportHelpers.prepareBaseObject(item, "vehicle");
             data.items = [];

--- a/modules/importer/oggdude/importers/weapons.js
+++ b/modules/importer/oggdude/importers/weapons.js
@@ -32,14 +32,12 @@ export default class Weapons {
             const itemType = item.Type === "Vehicle" ? "shipweapon" : "weapon";
             let pack = packs[itemType];
 
-            if (item.Description.split('\n').length > 0) {
-              item.Description = item.Description.replace('\n\n', '\n').split('\n').slice(1).join('<br>');
-            }
+            item.Description = ImportHelpers.cleanDescription(item.Description);
 
             let data = ImportHelpers.prepareBaseObject(item, itemType);
             data.data = {
               attributes: {},
-              description: item.Description.replace('[H3]', '<h3>').replace('[h3]', '</h3>').replace('[BR]', '<br>'),
+              description: item.Description,
               encumbrance: {
                 value: item.Encumbrance ? parseInt(item.Encumbrance, 10) : 0,
                 adjusted: item.Encumbrance ? parseInt(item.Encumbrance, 10) : 0,


### PR DESCRIPTION
**Why is this necessary:**
When importing certain data, formatting bug may occur, or data may be missing entirely (such as the description text).

**What has been done:**
- Fixed a formatting error during import that caused the description block for careers to be empty. (ef14b5152679a84e8ba4dd9ceca7e76ce8382074)
- Fixed an import issue (#2170) that could corrupt the entire dataset import when modifying Skills.xml; this occurred if the ```<Name>``` element contained a translation into another language. (1053d3be3cd5c2aa6151d587f2a3910d8b563624)
- A bug in the Specializations import feature that did not account for the presence of tags has been fixed. Now, if a user wants to add tags to Specializations, the system will correctly read them from the Specializations file. (206b781188d07ca62f9cec316a9757b58c34ef80)
- The import of sources (#2268) has been updated; these sources could be of the following types: ```<Source>User Data</Source>``` and ```<Source/> <Source/>```. (1a190f4afee71bfa67ba2cd13f84b3f8584df1b2)

**Checks:**

- [x] Tested with the latest version of the system at the time of pull publication.
- [x] Additional testing was carried out to detect errors

P.S
Fixing the bug with “Sources” (1a190f4afee71bfa67ba2cd13f84b3f8584df1b2) won't completely resolve the issue. This is because the window's design itself doesn't allow you to scroll down far enough to see the existing “Sources”.
