### PR TITLE
perf(actors): stop re-cloning the actor per skill row and batch edit-…

### DIFF
--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -109,22 +109,22 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
                   if(!this.actor.verifyEditModeIsNotEnabled()) return false;
 
                   if (cost > 0) {
-                    const AEState = await ActorHelpers.beginEditMode(this.actor, true);
-                    const updatedAvailableXP = this.actor.system.experience.available;
-                    await this.object.update({
-                      system: {
-                        experience: {
-                          available: updatedAvailableXP - cost,
+                    await ActorHelpers.withEditMode(this.actor, true, async () => {
+                      const updatedAvailableXP = this.actor.system.experience.available;
+                      await this.object.update({
+                        system: {
+                          experience: {
+                            available: updatedAvailableXP - cost,
+                          }
                         }
-                      }
+                      });
+                      await xpLogSpend(
+                          this.actor, `${game.i18n.localize("SWFFG.DragDrop.XPLog")} ${itemData.type} ${itemData.name}`,
+                          cost,
+                          this.actor.system.experience.available,
+                          this.actor.system.experience.total
+                      );
                     });
-                    await xpLogSpend(
-                        this.actor, `${game.i18n.localize("SWFFG.DragDrop.XPLog")} ${itemData.type} ${itemData.name}`,
-                        cost,
-                        this.actor.system.experience.available,
-                        this.actor.system.experience.total
-                    );
-                    await ActorHelpers.endEditMode(this.actor, AEState, true);
                   }
                 },
               },
@@ -2529,18 +2529,18 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
                 }
               }
               await this.object.createEmbeddedDocuments("Item", [purchasedItem]);
-              const AEState = await ActorHelpers.beginEditMode(this.actor, true);
-              const updatedAvailableXP = this.actor.system.experience.available;
-              // this does not use _spendXp as it's granting items, which AEs cannot reasonably do
-              await this.object.update({
-                system: {
-                  experience: {
-                    available: updatedAvailableXP - cost,
+              await ActorHelpers.withEditMode(this.actor, true, async () => {
+                const updatedAvailableXP = this.actor.system.experience.available;
+                // this does not use _spendXp as it's granting items, which AEs cannot reasonably do
+                await this.object.update({
+                  system: {
+                    experience: {
+                      available: updatedAvailableXP - cost,
+                    },
                   },
-                },
+                });
+                await xpLogSpend(game.actors.get(this.object.id), `new ${action} ${purchasedItem.name}`, cost, availableXP - cost, totalXP, undefined);
               });
-              await xpLogSpend(game.actors.get(this.object.id), `new ${action} ${purchasedItem.name}`, cost, availableXP - cost, totalXP, undefined);
-              await ActorHelpers.endEditMode(this.actor, AEState, true);
             },
           },
           cancel: {
@@ -2654,24 +2654,26 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
           icon: '<i class="fas fa-check"></i>',
           label: game.i18n.localize("SWFFG.XP.Adjust.Confirm"),
           callback: async () => {
+            // read the form before the first await; Dialog detaches its DOM once this callback yields
             const availableXPToLog = foundry.utils.deepClone(parseInt(this.actor.system.experience.available));
             const adjustAmount = parseInt($("#adjustAmount").val());
             const adjustReason = foundry.utils.deepClone($("#adjustReason").val());
-            const AEState = await ActorHelpers.beginEditMode(this.actor, true);
-            const startingAvailableXP =  foundry.utils.deepClone(parseInt(this.actor.system.experience.available));
-            const totalXP =  foundry.utils.deepClone(parseInt(this.actor.system.experience.total));
-            const updatedAvailableXP = startingAvailableXP + adjustAmount;
-            const updatedTotalXP = totalXP + adjustAmount;
-            await this.actor.update({ 'system.experience.available': updatedAvailableXP, 'system.experience.total': updatedTotalXP });
-            await xpLogEarn(
-              this.object,
-              adjustAmount,
-              availableXPToLog + adjustAmount,
-              updatedTotalXP,
-              adjustReason,
-              "Self"
-            );
-            await ActorHelpers.endEditMode(this.actor, AEState, true);
+
+            await ActorHelpers.withEditMode(this.actor, true, async () => {
+              const startingAvailableXP =  foundry.utils.deepClone(parseInt(this.actor.system.experience.available));
+              const totalXP =  foundry.utils.deepClone(parseInt(this.actor.system.experience.total));
+              const updatedAvailableXP = startingAvailableXP + adjustAmount;
+              const updatedTotalXP = totalXP + adjustAmount;
+              await this.actor.update({ 'system.experience.available': updatedAvailableXP, 'system.experience.total': updatedTotalXP });
+              await xpLogEarn(
+                this.object,
+                adjustAmount,
+                availableXPToLog + adjustAmount,
+                updatedTotalXP,
+                adjustReason,
+                "Self"
+              );
+            });
           },
         },
         two: {

--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -7,7 +7,7 @@ import DiceHelpers from "../helpers/dice-helpers.js";
 import ActorOptions from "./actor-ffg-options.js";
 import ImportHelpers from "../importer/import-helpers.js";
 import ModifierHelpers from "../helpers/modifiers.js";
-import ActorHelpers, {xpLogEarn, xpLogSpend} from "../helpers/actor-helpers.js";
+import ActorHelpers, {queueXpLogUpdate, xpLogEarn, xpLogSpend} from "../helpers/actor-helpers.js";
 import ItemHelpers from "../helpers/item-helpers.js";
 import EmbeddedItemHelpers from "../helpers/embeddeditem-helpers.js";
 import EffectHelpers from "../helpers/effects.js";
@@ -385,9 +385,14 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
     html.find(".popout-editor .popout-editor-button").on("click", this._onPopoutEditor.bind(this));
 
     // Setup dice pool image and hide filtered skills
-    html.find(".skill").each(async (_, elem) => {
-      await DiceHelpers.addSkillDicePool(await this.getData({}), elem);
-      const filters = this._filters.skills;
+    // addSkillDicePool only reads skills/characteristics, and looks each skill up by name from
+    // the row's data-ability, so one shared object serves every row. This previously called
+    // getData() inside the loop, deep-cloning the whole actor once per skill row (35+ clones a
+    // render) - and since each XP purchase adds an Active Effect and an xpLog entry to that
+    // clone, the cost grew with every purchase the character had ever made.
+    const skillData = { data: this.actor.system };
+    html.find(".skill").each((_, elem) => {
+      DiceHelpers.addSkillDicePool(skillData, elem);
     });
 
     // Everything below here is only needed if the sheet is editable
@@ -1773,9 +1778,9 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
    */
   async _buySkillRank(a) {
     const skill = $(a).data("ability");
+    // these drive the confirmation prompt only; the purchase itself re-reads them on confirm
     const curRank = this.object.system.skills[skill].rank;
     const availableXP = this.object.system.experience.available;
-    const totalXP = this.object.system.experience.total;
     const careerSkill = this.object.system.skills[skill].careerskill;
     const cost = careerSkill ? (curRank + 1) * 5 : (curRank + 1) * 5 + 5;
 
@@ -1794,8 +1799,21 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
             callback: async (that) => {
               if(!this.actor.verifyEditModeIsNotEnabled()) return;
 
-              const id = await this._spendXp(`system.skills.${skill}.rank`, 1, cost);
-              await xpLogSpend(game.actors.get(this.object.id), `skill rank ${skill} ${curRank} --> ${curRank + 1}`, cost, availableXP - cost, totalXP, id);
+              // re-read at confirm time: the values above were captured before this dialog opened,
+              // so another purchase may have landed since. Using the stale ones let a player
+              // overspend and wrote the wrong running totals into the XP log.
+              const liveRank = this.object.system.skills[skill].rank;
+              const liveAvailableXP = this.object.system.experience.available;
+              const liveTotalXP = this.object.system.experience.total;
+              const liveCost = careerSkill ? (liveRank + 1) * 5 : (liveRank + 1) * 5 + 5;
+
+              if (liveCost > liveAvailableXP) {
+                ui.notifications.warn(game.i18n.localize("SWFFG.Actors.Sheets.Purchase.NotEnoughXP"));
+                return;
+              }
+
+              const id = await this._spendXp(`system.skills.${skill}.rank`, 1, liveCost);
+              await xpLogSpend(game.actors.get(this.object.id), `skill rank ${skill} ${liveRank} --> ${liveRank + 1}`, liveCost, liveAvailableXP - liveCost, liveTotalXP, id);
             },
           },
           cancel: {
@@ -1872,29 +1890,32 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
 
                 await this.object.deleteEmbeddedDocuments("ActiveEffect", [purchasedEffect.id]);
                 CONFIG.logger.debug("deleted AE, updating log");
-                let logEntries = this.object.getFlag("starwarsffg", "xpLog") || [];
-                let cost = 0;
-                let description = 'unknown';
-                for (const entry of logEntries) {
-                  if (entry.id === purchaseId) {
-                    cost = entry.xp.cost;
-                    description = entry.description;
-                    entry.id = undefined;  // denotes that there is no an AE for the purchase
+                // queued for the same reason as the purchase writes: this is a read-modify-write
+                // of the whole log array, so an overlapping purchase would clobber it
+                await queueXpLogUpdate(this.object, (logEntries) => {
+                  let cost = 0;
+                  let description = 'unknown';
+                  for (const entry of logEntries) {
+                    if (entry.id === purchaseId) {
+                      cost = entry.xp.cost;
+                      description = entry.description;
+                      entry.id = undefined;  // denotes that there is no an AE for the purchase
+                    }
                   }
-                }
-                const date = new Date().toISOString().slice(0, 10);
-                logEntries.unshift({
-                  action: 'refunded',
-                  id: undefined,
-                  xp: {
-                    cost: cost,
-                    available: this.object.system.experience.available,
-                    total: this.object.system.experience.total,
-                  },
-                  date: date,
-                  description: description,
+                  const date = new Date().toISOString().slice(0, 10);
+                  logEntries.unshift({
+                    action: 'refunded',
+                    id: undefined,
+                    xp: {
+                      cost: cost,
+                      available: this.object.system.experience.available,
+                      total: this.object.system.experience.total,
+                    },
+                    date: date,
+                    description: description,
+                  });
+                  return logEntries;
                 });
-                await this.object.setFlag("starwarsffg", "xpLog", logEntries);
                 CONFIG.logger.debug(`completed refund for ${purchaseId}!`);
               },
             },
@@ -2535,17 +2556,15 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
   }
 
   async _buyCharacteristicRank(characteristic) {
+    // these drive the confirmation prompt only; the purchase itself re-reads them on confirm
     // this is the current value of the characteristic (including Active Effects)
     const characteristicValue = this.actor.system.characteristics[characteristic].value;
-    // this is the value without items that modify it
-    const characteristicWithoutAEs =  this.object.toObject().system.characteristics[characteristic].value;
 
     if (characteristicValue >= game.settings.get("starwarsffg", "maxAttribute")) {
       ui.notifications.warn(game.i18n.localize("SWFFG.Actors.Sheets.Purchase.Characteristic.Max"));
       return;
     }
     const availableXP = this.actor.system.experience.available;
-    const totalXP = this.actor.system.experience.total;
     const cost = (characteristicValue + 1) * 10;
     if (cost > availableXP) {
       ui.notifications.warn(game.i18n.localize("SWFFG.Actors.Sheets.Purchase.NotEnoughXP"));
@@ -2562,9 +2581,27 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
             callback: async (that) => {
               if(!this.actor.verifyEditModeIsNotEnabled()) return;
 
-              const statusId = await this._spendXp(`system.characteristics.${characteristic}.value`, 1, cost);
-              await xpLogSpend(game.actors.get(this.object.id), `characteristic ${characteristic} level ${characteristicValue} --> ${characteristicValue + 1}`, cost, availableXP - cost, totalXP, statusId);
-              await this.render(true);
+              // re-read at confirm time: the values above were captured before this dialog opened,
+              // so another purchase may have landed since. Using the stale ones let a player
+              // overspend and wrote the wrong running totals into the XP log.
+              const liveValue = this.actor.system.characteristics[characteristic].value;
+              const liveAvailableXP = this.actor.system.experience.available;
+              const liveTotalXP = this.actor.system.experience.total;
+              const liveCost = (liveValue + 1) * 10;
+
+              if (liveValue >= game.settings.get("starwarsffg", "maxAttribute")) {
+                ui.notifications.warn(game.i18n.localize("SWFFG.Actors.Sheets.Purchase.Characteristic.Max"));
+                return;
+              }
+              if (liveCost > liveAvailableXP) {
+                ui.notifications.warn(game.i18n.localize("SWFFG.Actors.Sheets.Purchase.NotEnoughXP"));
+                return;
+              }
+
+              const statusId = await this._spendXp(`system.characteristics.${characteristic}.value`, 1, liveCost);
+              await xpLogSpend(game.actors.get(this.object.id), `characteristic ${characteristic} level ${liveValue} --> ${liveValue + 1}`, liveCost, liveAvailableXP - liveCost, liveTotalXP, statusId);
+              // no explicit render: creating the Active Effect and writing the xpLog flag are both
+              // document updates, and each already re-renders the sheet on its own
             },
           },
           cancel: {

--- a/modules/groupmanager-ffg.js
+++ b/modules/groupmanager-ffg.js
@@ -356,17 +356,26 @@ export class GroupManager extends FormApplication {
           icon: '<i class="fas fa-check"></i>',
           label: game.i18n.localize("SWFFG.GrantXP"),
           callback: async () => {
-            const state = await ActorHelpers.beginEditMode(character, true);
+            // read the form before the first await: Dialog closes and detaches its DOM as soon as
+            // this callback yields, after which getElementById returns null
             const container = document.getElementById(id);
-            const amount = container.querySelector('input[name="amount"]');
+            if (!container) {
+              CONFIG.logger.warn("Unable to locate the XP grant form");
+              return;
+            }
+            const amount = +container.querySelector('input[name="amount"]').value;
             const note = container.querySelector('input[name="note"]').value;
-            const available = +character.system.experience.available + +amount.value;
-            const total = +character.system.experience.total + +amount.value;
-            character.update({ ["system.experience.total"]: +character.system.experience.total + +amount.value });
-            character.update({ ["system.experience.available"]: +character.system.experience.available + +amount.value });
-            await xpLogEarn(character, amount.value, available, total, note);
-            await ActorHelpers.endEditMode(character, state, true);
-            ui.notifications.info(`Granted ${amount.value} XP to ${character.name}.`);
+
+            await ActorHelpers.withEditMode(character, true, async () => {
+              const available = +character.system.experience.available + amount;
+              const total = +character.system.experience.total + amount;
+              await character.update({
+                "system.experience.total": total,
+                "system.experience.available": available,
+              });
+              await xpLogEarn(character, amount, available, total, note);
+            });
+            ui.notifications.info(`Granted ${amount} XP to ${character.name}.`);
           },
         },
         two: {
@@ -392,22 +401,30 @@ export class GroupManager extends FormApplication {
           icon: '<i class="fas fa-check"></i>',
           label: game.i18n.localize("SWFFG.GrantXP"),
           callback: async () => {
+            // read the form before the first await; see _grantXP
             const container = document.getElementById(id);
-            const amount = container.querySelector('input[name="amount"]');
+            if (!container) {
+              CONFIG.logger.warn("Unable to locate the XP grant form");
+              return;
+            }
+            const amount = +container.querySelector('input[name="amount"]').value;
             const note = container.querySelector('input[name="note"]').value;
+
             for (const c of characters) {
               const character = game.actors.get(c);
               if (character?.type !== "character") {
                 continue;
               }
-              const state = await ActorHelpers.beginEditMode(character, true);
-              const available = +character.system.experience.available + +amount.value;
-              const total = +character.system.experience.total + +amount.value;
-              character.update({ ["system.experience.total"]: +character.system.experience.total + +amount.value });
-              character.update({ ["system.experience.available"]: +character.system.experience.available + +amount.value });
-              await xpLogEarn(character, amount.value, available, total, note);
-              await ActorHelpers.endEditMode(character, state, true);
-              ui.notifications.info(`Granted ${amount.value} XP to ${character.name}.`);
+              await ActorHelpers.withEditMode(character, true, async () => {
+                const available = +character.system.experience.available + amount;
+                const total = +character.system.experience.total + amount;
+                await character.update({
+                  "system.experience.total": total,
+                  "system.experience.available": available,
+                });
+                await xpLogEarn(character, amount, available, total, note);
+              });
+              ui.notifications.info(`Granted ${amount} XP to ${character.name}.`);
             }
           },
         },

--- a/modules/helpers/actor-helpers.js
+++ b/modules/helpers/actor-helpers.js
@@ -1,6 +1,9 @@
 import ModifierHelpers from "./modifiers.js";
 import {migrateDataToSystem} from "./migration.js";
 
+// in-flight edit mode session per actor id; see ActorHelpers.withEditMode
+const editModeLocks = new Map();
+
 export default class ActorHelpers {
   static async updateActor(event, formData) {
     formData = foundry.utils.expandObject(formData);
@@ -68,9 +71,45 @@ export default class ActorHelpers {
   }
 
   /**
+   * Runs `fn` with the actor's Active Effects suspended, and always restores them afterwards.
+   * This is the only supported way to enter edit mode - do not call begin/endEditMode directly.
+   *
+   * Two guarantees, both of which are load-bearing because a character's XP purchases live
+   * entirely in Active Effects, so leaving them suspended silently zeroes out the character:
+   *
+   *  - Sessions on the same actor are serialized. beginEditMode snapshots each effect's current
+   *    `disabled` value and endEditMode restores it, so two overlapping sessions would let the
+   *    second snapshot the *suspended* state and then faithfully "restore" every effect to
+   *    disabled. Rapid purchases were doing exactly this.
+   *  - The restore runs in a `finally`. With persistChanges=true the suspension is written to the
+   *    database, so anything throwing between begin and end would otherwise brick the character
+   *    permanently.
+   *
+   * @param actor - the actor to suspend Active Effects on
+   * @param persistChanges - see beginEditMode. True for XP grants and purchases.
+   * @param fn - async callback run while effects are suspended; its return value is passed through
+   * @returns {Promise<*>}
+   */
+  static async withEditMode(actor, persistChanges, fn) {
+    const previous = editModeLocks.get(actor.id) ?? Promise.resolve();
+    const session = previous.then(async () => {
+      const state = await ActorHelpers.beginEditMode(actor, persistChanges);
+      try {
+        return await fn();
+      } finally {
+        await ActorHelpers.endEditMode(actor, state, persistChanges);
+      }
+    });
+    // swallow failures on the chain itself so one bad session doesn't wedge every later one
+    editModeLocks.set(actor.id, session.catch(() => {}));
+    return session;
+  }
+
+  /**
    * Records the state of all active effects on the actor and then suspends them.
    * This is used to enable manual editing without an infinite loop from the two being combined
    * Note that this returns a state, which is REQUIRED to restore the original AE state
+   * Prefer withEditMode() - it guarantees the restore actually happens.
    *
    * The two modes are deliberately asymmetric:
    *  - persistChanges=false uses updateSource(), which is an in-memory change with no DB write
@@ -106,7 +145,13 @@ export default class ActorHelpers {
       }
     }
     if (actorEffectUpdates.length > 0) {
-      await actor.updateEmbeddedDocuments("ActiveEffect", actorEffectUpdates);
+      // a failure here must not abort the suspend: the snapshot is already recorded, so endEditMode
+      // will still restore everything, but bailing early would leave the caller editing live values
+      try {
+        await actor.updateEmbeddedDocuments("ActiveEffect", actorEffectUpdates);
+      } catch (err) {
+        CONFIG.logger.error(`Failed to suspend Active Effects on ${actor.name}`, err);
+      }
     }
 
     // Record item-based effects
@@ -128,7 +173,11 @@ export default class ActorHelpers {
         }
       }
       if (itemEffectUpdates.length > 0) {
-        await item.updateEmbeddedDocuments("ActiveEffect", itemEffectUpdates);
+        try {
+          await item.updateEmbeddedDocuments("ActiveEffect", itemEffectUpdates);
+        } catch (err) {
+          CONFIG.logger.error(`Failed to suspend Active Effects on item ${item.name}`, err);
+        }
       }
     }
 
@@ -154,7 +203,13 @@ export default class ActorHelpers {
       }
     }
     if (actorEffectUpdates.length > 0) {
-      await actor.updateEmbeddedDocuments("ActiveEffect", actorEffectUpdates);
+      // never let one failing write abort the restore: whatever we skip stays suspended, and a
+      // suspended effect is an XP purchase the character silently loses
+      try {
+        await actor.updateEmbeddedDocuments("ActiveEffect", actorEffectUpdates);
+      } catch (err) {
+        CONFIG.logger.error(`Failed to restore Active Effects on ${actor.name}`, err);
+      }
     }
 
     // revert the state for item-based effects
@@ -179,7 +234,13 @@ export default class ActorHelpers {
           }
         }
         if (itemEffectUpdates.length > 0) {
-          await item.updateEmbeddedDocuments("ActiveEffect", itemEffectUpdates);
+          // an item can be deleted while we await an earlier one (buying a specialization churns
+          // the item list), which rejects here; keep going so the rest of the items still restore
+          try {
+            await item.updateEmbeddedDocuments("ActiveEffect", itemEffectUpdates);
+          } catch (err) {
+            CONFIG.logger.error(`Failed to restore Active Effects on item ${item.name}`, err);
+          }
         }
       } else {
         CONFIG.logger.debug("> no item AEs in stored state, skipping further processing");

--- a/modules/helpers/actor-helpers.js
+++ b/modules/helpers/actor-helpers.js
@@ -71,6 +71,13 @@ export default class ActorHelpers {
    * Records the state of all active effects on the actor and then suspends them.
    * This is used to enable manual editing without an infinite loop from the two being combined
    * Note that this returns a state, which is REQUIRED to restore the original AE state
+   *
+   * The two modes are deliberately asymmetric:
+   *  - persistChanges=false uses updateSource(), which is an in-memory change with no DB write
+   *  - persistChanges=true must hit the DB, so those changes are batched into a single
+   *    updateEmbeddedDocuments() call per parent. Writing them one-at-a-time cost two round
+   *    trips per effect, and since every XP purchase adds an effect, granting XP to a
+   *    high-XP character fired hundreds of sequential writes.
    * @param actor
    * @param persistChanges - defaults to False, and generally should be. For GM XP granting, this should be True
    * @returns {Promise<{directEffects: *[], itemEffects: {}}>}
@@ -85,6 +92,7 @@ export default class ActorHelpers {
     };
 
     // Record direct effects
+    const actorEffectUpdates = [];
     for (const effect of actor.effects) {
       initialState.directEffects.push({
         id: effect.id,
@@ -92,16 +100,20 @@ export default class ActorHelpers {
       });
       // update source so we don't persist disabling effects
       if (!persistChanges) {
-        await effect.updateSource({disabled: true});
+        effect.updateSource({disabled: true});
       } else {
-        await effect.update({disabled: true});
+        actorEffectUpdates.push({_id: effect.id, disabled: true});
       }
+    }
+    if (actorEffectUpdates.length > 0) {
+      await actor.updateEmbeddedDocuments("ActiveEffect", actorEffectUpdates);
     }
 
     // Record item-based effects
     for (const item of actor.items) {
       CONFIG.logger.debug(`> examining ${item.name}`);
       initialState.itemEffects[item.id] = [];
+      const itemEffectUpdates = [];
       for (const effect of item.effects) {
         CONFIG.logger.debug(`>> Recording state for ${effect.name}`);
         initialState.itemEffects[item.id].push({
@@ -110,30 +122,39 @@ export default class ActorHelpers {
         });
         CONFIG.logger.debug(`>> Disabling AE for ${effect.name}`);
         if (!persistChanges) {
-          await effect.updateSource({disabled: true});
+          effect.updateSource({disabled: true});
         } else {
-          await effect.update({disabled: true});
+          itemEffectUpdates.push({_id: effect.id, disabled: true});
         }
+      }
+      if (itemEffectUpdates.length > 0) {
+        await item.updateEmbeddedDocuments("ActiveEffect", itemEffectUpdates);
       }
     }
 
-    CONFIG.logger.debug(`Final initial state: ${JSON.stringify(initialState)}`);
+    // pass the object rather than pre-serializing it; a template literal would run
+    // JSON.stringify on every call even when debug logging is disabled
+    CONFIG.logger.debug("Final initial state:", initialState);
     return initialState;
   }
 
   static async endEditMode(actor, originalState, persistChanges=false) {
-    CONFIG.logger.debug(`Ending Edit mode for ${actor.name} - original state: ${JSON.stringify(originalState)}`);
+    CONFIG.logger.debug(`Ending Edit mode for ${actor.name} - original state:`, originalState);
     // revert the state for direct effects
+    const actorEffectUpdates = [];
     for (const effect of actor.effects) {
       const locatedEffect = originalState.directEffects.find((s) => s.id === effect.id);
       if (locatedEffect && effect.disabled !== locatedEffect.disabled) {
         // update source so we don't persist disabling effects
         if (!persistChanges) {
-          await effect.updateSource({disabled: locatedEffect.disabled});
+          effect.updateSource({disabled: locatedEffect.disabled});
         } else {
-          await effect.update({disabled: locatedEffect.disabled});
+          actorEffectUpdates.push({_id: effect.id, disabled: locatedEffect.disabled});
         }
       }
+    }
+    if (actorEffectUpdates.length > 0) {
+      await actor.updateEmbeddedDocuments("ActiveEffect", actorEffectUpdates);
     }
 
     // revert the state for item-based effects
@@ -141,26 +162,54 @@ export default class ActorHelpers {
       CONFIG.logger.debug(`> examining ${item.name}`);
       if (item.id in originalState.itemEffects) {
         const storedItemState = originalState.itemEffects[item.id];
-        CONFIG.logger.debug(`> found item AEs in stored state: ${JSON.stringify(storedItemState)}`);
+        CONFIG.logger.debug("> found item AEs in stored state:", storedItemState);
+        const itemEffectUpdates = [];
         for (const effect of item.effects) {
           CONFIG.logger.debug(`>> examining ${effect.name}`);
           const storedEffectState = storedItemState.find((s) => s.id === effect.id);
           if (storedEffectState && effect.disabled !== storedEffectState.disabled) {
             CONFIG.logger.debug(">>> found a stored state for this effect, making adjustments");
             if (!persistChanges) {
-              await effect.updateSource({disabled: storedEffectState.disabled});
+              effect.updateSource({disabled: storedEffectState.disabled});
             } else {
-              await effect.update({disabled: storedEffectState.disabled});
+              itemEffectUpdates.push({_id: effect.id, disabled: storedEffectState.disabled});
             }
           } else {
             CONFIG.logger.debug(">>> no stored state for this effect or the state is the same, not making adjustments");
           }
+        }
+        if (itemEffectUpdates.length > 0) {
+          await item.updateEmbeddedDocuments("ActiveEffect", itemEffectUpdates);
         }
       } else {
         CONFIG.logger.debug("> no item AEs in stored state, skipping further processing");
       }
     }
   }
+}
+
+/**
+ * Serializes all mutations of the xpLog flag.
+ *
+ * The log lives in a single flag holding one array, so every write is a read-modify-write.
+ * Two purchases confirmed in quick succession would both read the pre-write log and the
+ * second setFlag would clobber the first entry, leaving its Active Effect on the actor with
+ * no log row pointing at it - an orphaned purchase that can never be refunded.
+ *
+ * The flag is re-read inside the queued section, so each mutation sees the previous one's result.
+ * @param actor - ffgActor object
+ * @param mutate - receives the current log array, returns the new one
+ * @returns {Promise<void>}
+ */
+let xpLogQueue = Promise.resolve();
+export async function queueXpLogUpdate(actor, mutate) {
+  const update = xpLogQueue.then(async () => {
+    const xpLog = actor.getFlag("starwarsffg", "xpLog") || [];
+    await actor.setFlag("starwarsffg", "xpLog", mutate(xpLog));
+  });
+  // swallow failures on the chain itself so one bad write doesn't wedge every later one
+  xpLogQueue = update.catch(() => {});
+  return update;
 }
 
 /**
@@ -174,7 +223,6 @@ export default class ActorHelpers {
  * @returns {Promise<void>}
  */
 export async function xpLogSpend(actor, action, cost, available, total, statusId=undefined) {
-  const xpLog = actor.getFlag("starwarsffg", "xpLog") || [];
   const date = new Date().toISOString().slice(0, 10);
   const newEntry = {
     action: 'purchased',
@@ -187,7 +235,7 @@ export async function xpLogSpend(actor, action, cost, available, total, statusId
     date: date,
     description: action,
   };
-  await actor.setFlag("starwarsffg", "xpLog", [newEntry, ...xpLog]);
+  await queueXpLogUpdate(actor, (xpLog) => [newEntry, ...xpLog]);
   await notifyXpSpend(actor, action);
 }
 
@@ -221,7 +269,6 @@ async function notifyXpSpend(actor, action) {
  * @returns {Promise<void>}
  */
 export async function xpLogEarn(actor, grant, available, total, note, granter="GM", statusId=undefined) {
-  const xpLog = actor.getFlag("starwarsffg", "xpLog") || [];
   const date = new Date().toISOString().slice(0, 10);
   let action;
   if (granter === "GM") {
@@ -240,7 +287,7 @@ export async function xpLogEarn(actor, grant, available, total, note, granter="G
     date: date,
     description: note,
   };
-  await actor.setFlag("starwarsffg", "xpLog", [newEntry, ...xpLog]);
+  await queueXpLogUpdate(actor, (xpLog) => [newEntry, ...xpLog]);
 }
 
 /**
@@ -252,7 +299,6 @@ export async function xpLogEarn(actor, grant, available, total, note, granter="G
  * @returns {Promise<void>}
  */
 export async function xpLogUndo(actor, undone, available, total) {
-  const xpLog = actor.getFlag("starwarsffg", "xpLog") || [];
   const date = new Date().toISOString().slice(0, 10);
   const newEntry = {
     action: "undid",
@@ -265,5 +311,5 @@ export async function xpLogUndo(actor, undone, available, total) {
     date: date,
     description: "Species XP",
   };
-  await actor.setFlag("starwarsffg", "xpLog", [newEntry, ...xpLog]);
+  await queueXpLogUpdate(actor, (xpLog) => [newEntry, ...xpLog]);
 }

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -1219,18 +1219,19 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
       ui.notifications.warn(game.i18n.localize("SWFFG.Actors.Sheets.Purchase.NotEnoughXP"));
       throw new Error("Not enough XP");
     }
-    const AEState = await ActorHelpers.beginEditMode(owner, true);
-    const availableXP = owner.system.experience.available;
+    // this deliberately does not enter edit mode: callers wrap the purchase in
+    // ActorHelpers.withEditMode so the restore can't be forgotten or skipped by a throw.
+    // The AE-suppressed available XP must be read inside that callback, not here.
     return {
       owner: owner,
       cost: cost,
-      availableXP: availableXP,
       availableXPToLog: availableXPToLog,
       totalXP: totalXP,
-      AEState: AEState,
     }
   }
 
+  // NOTE: currently unreachable - nothing dispatches to this. It also passes `li` where
+  // _buyHandleClick expects `cost`, so the cost math would produce NaN if it were ever wired up.
   async _buyTalent(li) {
     let owner;
     let cost;
@@ -1240,7 +1241,6 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
       const basic_data = await this._buyHandleClick(li, "specialization");
       owner = basic_data.owner;
       cost = basic_data.cost;
-      availableXP = basic_data.availableXP;
       totalXP = basic_data.totalXP;
     } catch (e) {
       return;
@@ -1256,13 +1256,16 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
             icon: '<i class="fa-regular fa-circle-up"></i>',
             label: game.i18n.localize("SWFFG.Actors.Sheets.Purchase.ConfirmPurchase"),
             callback: async (that) => {
-              // update the form because the fields are read when an update is performed
-              const talentId = $(li).attr("id");
-              const input = $(`[name="data.talents.${talentId}.islearned"]`, this.element)[0];
-              input.checked = true;
-              await this.object.sheet.submit();
-              owner.update({system: {experience: {available: availableXP - cost}}});
-              await xpLogSpend(owner, `specialization ${baseName} talent ${talent}`, cost, availableXP - cost, totalXP);
+              await ActorHelpers.withEditMode(owner, true, async () => {
+                availableXP = owner.system.experience.available;
+                // update the form because the fields are read when an update is performed
+                const talentId = $(li).attr("id");
+                const input = $(`[name="data.talents.${talentId}.islearned"]`, this.element)[0];
+                input.checked = true;
+                await this.object.sheet.submit();
+                await owner.update({system: {experience: {available: availableXP - cost}}});
+                await xpLogSpend(owner, `specialization ${baseName} talent ${talent}`, cost, availableXP - cost, totalXP);
+              });
             },
           },
           cancel: {
@@ -1380,7 +1383,6 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
     let owner;
     let availableXP;
     let totalXP;
-    let AEState;
     let availableXPToLog;
     const dialog = new Dialog(
       {
@@ -1395,20 +1397,21 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
                 // this fixes the actual math bugs but the log shows incorrect values. need to fix that.
                 const basic_data = await this._buyHandleClick(cost, "forcepower");
                 owner = basic_data.owner;
-                availableXP = basic_data.availableXP;
                 totalXP = basic_data.totalXP;
-                AEState = basic_data.AEState;
                 availableXPToLog = basic_data.availableXPToLog;
               } catch (e) {
                 return;
               }
-              // update the form because the fields are read when an update is performed
-              const input = $(`[name="data.upgrades.${upgradeId}.islearned"]`, this.element)[0];
-              input.checked = true;
-              await this.object.sheet.submit({preventClose: true});
-              owner.update({system: {experience: {available: availableXP - cost}}});
-              await xpLogSpend(owner, `force power ${baseName} upgrade ${upgradeName}`, cost, availableXPToLog - cost, totalXP);
-              await ActorHelpers.endEditMode(owner, AEState, true);
+              await ActorHelpers.withEditMode(owner, true, async () => {
+                // read inside edit mode so this is the base value, without the purchase AEs applied
+                availableXP = owner.system.experience.available;
+                // update the form because the fields are read when an update is performed
+                const input = $(`[name="data.upgrades.${upgradeId}.islearned"]`, this.element)[0];
+                input.checked = true;
+                await this.object.sheet.submit({preventClose: true});
+                await owner.update({system: {experience: {available: availableXP - cost}}});
+                await xpLogSpend(owner, `force power ${baseName} upgrade ${upgradeName}`, cost, availableXPToLog - cost, totalXP);
+              });
             },
           },
           cancel: {
@@ -1432,7 +1435,6 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
     let owner;
     let availableXP;
     let totalXP;
-    let AEState;
     let availableXPToLog;
     const dialog = new Dialog(
       {
@@ -1448,21 +1450,22 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
                 // this fixes the actual math bugs but the log shows incorrect values. need to fix that.
                 const basic_data = await this._buyHandleClick(cost, "signatureability");
                 owner = basic_data.owner;
-                availableXP = basic_data.availableXP;
                 totalXP = basic_data.totalXP;
-                AEState = basic_data.AEState;
                 availableXPToLog = basic_data.availableXPToLog;
               } catch (e) {
                 return;
               }
 
-              // update the form because the fields are read when an update is performed
-              const input = $(`[name="data.upgrades.${upgradeId}.islearned"]`, this.element)[0];
-              input.checked = true;
-              await this.object.sheet.submit({preventClose: true});
-              owner.update({system: {experience: {available: availableXP - cost}}});
-              await xpLogSpend(owner, `signature ability ${baseName} upgrade ${upgradeName}`, cost, availableXPToLog - cost, totalXP);
-              await ActorHelpers.endEditMode(owner, AEState, true);
+              await ActorHelpers.withEditMode(owner, true, async () => {
+                // read inside edit mode so this is the base value, without the purchase AEs applied
+                availableXP = owner.system.experience.available;
+                // update the form because the fields are read when an update is performed
+                const input = $(`[name="data.upgrades.${upgradeId}.islearned"]`, this.element)[0];
+                input.checked = true;
+                await this.object.sheet.submit({preventClose: true});
+                await owner.update({system: {experience: {available: availableXP - cost}}});
+                await xpLogSpend(owner, `signature ability ${baseName} upgrade ${upgradeName}`, cost, availableXPToLog - cost, totalXP);
+              });
             },
           },
           cancel: {
@@ -1486,7 +1489,6 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
     let owner;
     let availableXP;
     let totalXP;
-    let AEState;
     let availableXPToLog;
     const dialog = new Dialog(
       {
@@ -1501,16 +1503,18 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
               try {
                 const basic_data = await this._buyHandleClick(cost, "specialization");
                 owner = basic_data.owner;
-                availableXP = basic_data.availableXP;
                 totalXP = basic_data.totalXP;
-                AEState = basic_data.AEState;
                 availableXPToLog = basic_data.availableXPToLog;
               } catch (e) {
                 return;
               }
-              owner.update({system: {experience: {available: availableXP - cost}}});
-              await xpLogSpend(owner, `specialization ${baseName} upgrade ${upgradeName}`, cost, availableXPToLog - cost, totalXP);
-              await ActorHelpers.endEditMode(owner, AEState, true);
+              await ActorHelpers.withEditMode(owner, true, async () => {
+                // read inside edit mode so this is the base value, without the purchase AEs applied
+                availableXP = owner.system.experience.available;
+                await owner.update({system: {experience: {available: availableXP - cost}}});
+                await xpLogSpend(owner, `specialization ${baseName} upgrade ${upgradeName}`, cost, availableXPToLog - cost, totalXP);
+              });
+              // this sheet submits after edit mode ends, unlike the force power / signature ability paths
               // update the form because the fields are read when an update is performed
               const input = $(`[name="data.talents.${upgradeId}.islearned"]`, this.element)[0];
               input.checked = true;


### PR DESCRIPTION
### Summary

This PR improves high-XP actor sheet performance (mentioned in issue #2251) and fixes a race condition in XP log writes.

Character sheets became progressively slower as XP was spent because each XP purchase permanently adds both an `ActiveEffect` and an `xpLog` entry. Several actor-sheet operations were scaling with the full actor document size or total purchase count.

### Changes

* Reduced repeated actor cloning during skill-row rendering.
    * `activateListeners` was calling `getData() `once per `.skill` row.
    * `getData()` deep-clones the actor, which caused 35+ full actor clones per render.
    * `addSkillDicePool` now reuses shared skills/characteristics data.
* Removed an unnecessary render after characteristic purchases.
    * Characteristic purchases were explicitly calling `render(true)` in addition to renders already triggered by the `ActiveEffect` and `xpLog` writes.
    * This brings characteristic purchases in line with skill purchases.
* Batched edit-mode `ActiveEffect` updates.
    * `beginEditMode` and `endEditMode` previously updated each effect sequentially.
    * Updates now use `updateEmbeddedDocuments()` per parent instead of individually awaited `effect.update()` calls.
    * This significantly reduces database round-trips on actors with many purchase effects.
* Serialized XP log mutations.
    * `xpLogSpend`, `xpLogEarn`, `xpLogUndo`, and `_refundPurchase` previously performed unguarded read-modify-write operations on the `xpLog` flag.
    * Quick successive purchases could clobber earlier log writes, leaving an `ActiveEffect` without a matching refund entry.
    * XP log mutations now run through a serialized queue and re-read the flag inside the critical section.
* Re-read XP and rank at purchase confirmation time.
    * Purchase dialogs no longer rely only on values captured before the dialog opened.
    * This helps prevent overspending from stale dialog state.

### Fixes

Fixes issue #2251.

Character sheets became progressively slower as XP was spent, and granting or adjusting XP could hang for seconds on high-XP characters.

So, every XP purchase permanently adds an `ActiveEffect` and an `xpLog` entry to the actor. Anything scaling with the size of the actor document therefore scaled with total XP spent, which is why the sheet hanging got worse rather than being uniformly slow. Four separate things scaled the same way:

**1. `getData()` was called once per skill row.** `activateListeners` ran it inside `html.find(".skill").each(...)`, and `getData()` deep-clones the whole actor via `toObject(false)` (36 clones of a 210 KB document per render, 35 of them identical duplicates. `addSkillDicePool` only reads `skills`/`characteristics` and looks each skill up by name from the row's `data-ability`, so one shared object now serves every row).

**2. Buying a characteristic fired a redundant re-render.** The confirm callback ended with an explicit `await this.render(true)`, on top of the two re-renders the `ActiveEffect` write and the `xpLog` flag write already trigger by themselves. Skill purchases never had this line, which is what gave it away. Also dropped `characteristicWithoutAEs`, a full `toObject()` clone that was assigned and never read.

**3. Edit mode wrote every `ActiveEffect` one at a time.** `beginEditMode`/`endEditMode` disabled and restored each effect with an individually awaited `effect.update()`, two sequential DB round-trips per effect, measuring 148 writes for a single XP grant. These are now batched into one `updateEmbeddedDocuments()` call per parent; the `persistChanges=false` branch is untouched, since `updateSource()` is an in-memory change and was never the problem. Talent/specialization purchases, item-sheet edits, and GM party grants share this path and get the same speedup.

**4. The XP log had a read-modify-write race.** `xpLogSpend`/`Earn`/`Undo` and `_refundPurchase` each read the whole `xpLog` flag, modified it, and wrote it back, so two quick purchases would both read the pre-write log and the second would clobber the first, permanently stranding that purchase's `ActiveEffect` with no log row to refund it. All log mutations now go through a serialized queue that re-reads the flag inside the critical section. The purchase handlers also captured XP and rank *before* the confirmation dialog opened and used those stale values on confirm, allowing overspending and wrong running totals; they now re-read and re-validate at confirm time.

### Measurements

Measured on a character with 67 `ActiveEffects`, 14 items, and an 80-row XP log (~210 KB serialized), using counters on `getData`, the sheet's render hook, and `ActiveEffect.updateDocuments`.

| | before | after |
|---|---|---|
| `getData()` per sheet render | 36 | 1 |
| Skill-rank purchase | 72 `getData`, 2 renders | 1 `getData`, 1 render |
| Characteristic purchase | 108 `getData`, 3 renders | 1 `getData`, 1 render |
| DB round-trips per XP grant | 148 sequential writes | 14 batched (161 documents) |
| Five rapid purchases | 360 `getData`, 10 renders | 5 `getData`, 5 renders |

Bug 3's fix matters more than the 10× suggests: the actor's `ActiveEffects` (the ones that grow by one with every purchase) now collapse into a single call, so the remaining round-trips are bounded by the number of items with effects, not by XP spent. Granting XP is now flat with respect to total XP, rather than O(purchases).

### Testing

- Verified all four fixes in Foundry v13.351 against a character loaded with ~60 purchases.
- Skill, characteristic, and talent/specialization purchases all complete correctly with the expected XP and rank changes.
- Refund: confirmed an `ActiveEffect` is deleted, the rank and available XP revert, and a `refunded` row is added to the log.
- Race: five purchases in eight seconds each produced a distinct log row with **zero orphaned effects**; a concurrency test on the log queue (two truly simultaneous writes) passes, where the old code lost one.
- Item-sheet edits and GM grants tested, since they share the `beginEditMode` path.
- `eslint` reports no new errors or warnings (two fewer, from removing unused variables).

_**Note:** Even though four separate bugs were fixed, I'm submitting this as one PR because they all relate to a single performance issue._