### PR TITLE
Foundry v14

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,10 @@
 
 # Base URL of the Foundry VTT server the Playwright e2e tests run against.
 # Scheme, host and port only - no trailing path.
-FOUNDRY_URL=http://localhost:30000
+FOUNDRY_URL=http://localhost:30001
+
+# Browser tests create and delete documents. Use a separate User Data folder.
+# The join page title/version and the loaded world ID are checked before tests.
+FOUNDRY_TEST_WORLD=starwarsffg-v14-test
+FOUNDRY_TEST_WORLD_TITLE=Star Wars FFG v14 Test
+FOUNDRY_TEST_GENERATION=14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+`Unreleased — Foundry V14 migration in progress`
+* Adapt chat authors, message styles, render hooks and dice audio to current APIs.
+* Route roll visibility through the v14 message-mode API, retaining v13 and legacy macro options.
+* Return plain chat data for deferred initiative messages and keep hidden combatants' public initiative rolls private.
+* Generate typed Active Effect changes on v14; preserve effect metadata when updating ranks and forward the effect application phase.
+* Remove obsolete token effect access from the combat tracker and use current effect images and duration labels.
+* Add isolated compatibility tests and require an explicitly identified disposable world for browser tests.
+* Allow v14 development testing; compatibility remains verified at v13 until the v14 runtime checks in `docs/foundry-v14.md` are complete.
+
 `2.0.4`
 * Fixes:
   * Fixed some issues with the importer code, [@KamiliaBlow](https://github.com/KamiliaBlow))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@
 * Return plain chat data for deferred initiative messages and keep hidden combatants' public initiative rolls private.
 * Generate typed Active Effect changes on v14; preserve effect metadata when updating ranks and forward the effect application phase.
 * Remove obsolete token effect access from the combat tracker and use current effect images and duration labels.
+* Restore the chat dice button beside the v14 message-mode controls and correctly map public rolls and legacy default-mode arguments.
+* Avoid circular Document traversal when rendering item sheets or removing embedded item attributes.
+* Prevent initial Force bonuses from being counted again in the final effect phase; exclude inactive bonuses.
+* Render v14 effect changes as plain display data without writing through core compatibility accessors.
+* Preserve once-per-roll and combat effect durations in the v14 Active Effect data model.
+* Copy source effect durations during item drops, synchronize equipment/accessory effects, and keep installed vehicle components active.
+* Enrich item-sheet copies without mutating live documents and create missing inherent bonuses when editing a new species.
+* Prepare items synchronously so sheet snapshots include the complete talent tree and calculated values.
 * Add isolated compatibility tests and require an explicitly identified disposable world for browser tests.
+* Update the browser test runner to Playwright 1.62.1 and adapt v14 login and WSL rendering.
 * Allow v14 development testing; compatibility remains verified at v13 until the v14 runtime checks in `docs/foundry-v14.md` are complete.
 
 `2.0.4`

--- a/docs/foundry-v14.md
+++ b/docs/foundry-v14.md
@@ -4,18 +4,26 @@
 
 - Branch: `misterWhite-foundry-v14`.
 - Starting commit: `a0a0b546e6171551bf37c55e2420eaafc0a04e56`.
-- Target runtime: Foundry VTT 14.367 (stable), checked 2026-09-08.
+- Target runtime: Foundry VTT 14.367 (stable), checked 2026-09-09.
 - Existing Windows runtime: Foundry VTT 13.351, serving the live `Star Wars` world on port 30000.
-- Current status: initial source adaptations and isolated tests only. **Not yet validated in Foundry 14.**
+- Current status: **27/27 integration tests pass against the installed development archive**, and **18/18 isolated compatibility tests pass**. The representative v13 backup completed core migration to 14.367. Its client acceptance awaits a GM login; full compatibility is **not yet verified**.
 - Manifest: minimum 13, verified 13, maximum 14. Maximum permits development testing; it is not a verification claim.
 
 ## Changes prepared
 
 Chat creation uses `author` and `style`. Chat rendering listens for `renderChatMessageHTML` and adapts its HTMLElement to the existing jQuery handlers. The dice audio call uses the namespaced AudioHelper.
 
-The roll boundary selects the correct core setting and API for v13/v14, accepts older macro roll-mode arguments, and returns plain document data for `create: false`. Initiative hides otherwise-public rolls for hidden combatants. The group manager uses the current private roll option for obligation/duty triggers.
+The roll boundary selects the correct core setting and API for v13/v14, accepts older macro roll-mode arguments, and returns plain document data for `create: false`. In v14 `public` is the public mode; the legacy `roll` sentinel uses the saved mode. Initiative hides otherwise-public rolls for hidden combatants. The group manager uses the current private roll option for obligation/duty triggers. The chat dice button now sits beside the v14 message-mode controls.
 
-Active Effect creation uses string change types on v14 and numeric modes on v13. Rank updates retain a change's type, phase and priority. The Actor override forwards the application phase. The sheet reads duration labels from v14's prepared effect, and the combat tracker reads actor effects rather than removed token fields.
+Active Effect creation uses string change types on v14 and numeric modes on v13. Rank updates retain a change's type, phase and priority. The Actor override forwards the application phase and prepares Force bonuses only during the initial phase, excluding inactive effects. The sheet builds plain display data from v14's system.changes and prepared duration label, avoiding core compatibility setters. The combat tracker reads actor effects rather than removed token fields.
+
+The v14 base Active Effect data model retains FFG's `system.duration` field, so once-per-roll and combat effects survive saving and expire through the existing system handlers.
+
+Item-sheet cleanup traverses item system data, avoiding circular Document references in the v14 sheet context. Item drops retain adjusted item values while copying effects from source data: prepared permanent durations contain Infinity and cannot be persisted.
+
+Item sheets enrich a plain copy of the Item rather than its live data. New species build missing inherent effect changes on their first edit. Equipment effects synchronize after item creation and accessory drops; installed vehicle components remain active without a character equip toggle.
+
+Item preparation is synchronous, as required by Foundry's document lifecycle. The previous asynchronous override allowed sheet snapshots to run before talent-tree visibility and calculated item values were ready.
 
 The public Karlinator fork was examined as a reference. Its changes are not merged: its manifest claim does not establish coverage of dice, message privacy or effects for this newer upstream checkout.
 
@@ -24,6 +32,8 @@ The public Karlinator fork was examined as a reference. Its changes are not merg
 `npm run compile` succeeds on the starting checkout. Its generated CSS differs from the checked-in file; that unrelated output was not included in this migration.
 
 Initial ESLint baseline: **119 errors and 466 warnings**. The first compatibility pass introduces no additional error messages. Existing errors remain and are not evidence of v14 compatibility.
+
+Current ESLint result: **119 errors and 464 warnings**, with no new error messages compared with that baseline. The final Sass compilation also succeeds in an isolated build directory, without changing the repository's pre-existing generated CSS.
 
 Run the isolated document-boundary tests with:
 
@@ -37,16 +47,16 @@ These tests execute the actual system roll and compatibility helpers against stu
 
 Use a separate Foundry 14 installation and a separate User Data folder. Do not launch this development system against the live Windows User Data folder. The tests create and delete documents.
 
-The official Node.js distribution ZIP is required. A Node 24.15.0 runtime is already present in WSL; check the downloaded Foundry package's engine requirements before selecting it. Authentication is required on the vendor website to download the archive. Activation/EULA steps, if prompted, must be completed before browser testing.
+The official `FoundryVTT-Node-14.367.zip` was installed and activated. Node 24.15.0 satisfies its declared requirement of `>=24.13.1 <25.0.0`.
 
-Proposed WSL locations, to create once the archive is available:
+Installed WSL locations:
 
 ```text
 /home/tonio2581/foundry-v14/          Application files
 /home/tonio2581/foundry-v14-data/     Disposable development data
 ```
 
-Use port 30001 if available. Link `Data/systems/starwarsffg` in the development data folder to the repository. Create a world with:
+The test instance uses port 30001, with UPnP disabled. Its `Data/systems/starwarsffg` links to this repository. The created world is:
 
 ```text
 ID:    starwarsffg-v14-test
@@ -54,7 +64,17 @@ Title: Star Wars FFG v14 Test
 MJ:    Gamemaster
 ```
 
-Create a separate player account for permission checks. Begin with no add-on modules.
+The separate `Player2` account is used for permission checks. There are no add-on modules. Do not open the test Gamemaster account in another browser while running Playwright: Foundry does not permit a second session to select an already-connected user.
+
+To start this installation from an Ubuntu terminal when it is stopped:
+
+```bash
+/home/tonio2581/.nvm/versions/node/v24.15.0/bin/node \
+  /home/tonio2581/foundry-v14/main.js \
+  --dataPath=/home/tonio2581/foundry-v14-data --port=30001 --upnp=false
+```
+
+Open `http://localhost:30001` in the Windows browser. Stop a foreground server with Ctrl+C. Keep Node 24 selected when running npm commands; the machine's default Node 20 cannot run this Foundry release.
 
 Copy `.env.example` to `.env` and set the actual test server URL. Browser setup checks the title/version before joining and checks the world ID, system and generation after joining. The title/version check is deliberately before GM login because login can itself trigger system migration.
 
@@ -64,24 +84,39 @@ After preparing the browser runtime and launching the disposable world:
 npm run test:e2e -- --trace on
 ```
 
-The existing browser tests and login locators were built for v13. The world checks are prepared, but v14 interface adaptations and execution remain outstanding.
+The login locators now support v13's select and v14's user picker. The player test explicitly starts with empty storage state, so it does not reuse the Gamemaster's server session.
 
-Test discovery succeeds: 16 existing Chromium scenarios are listed. `test:e2e` invokes the CLI bundled with `@playwright/test` so that the runner and fixtures share a version; the original dependency tree also contains a different standalone Playwright version. Discovery does not execute the scenarios.
+The suite contains 16 effect scenarios and 11 runtime compatibility scenarios in `e2e/runtimeCompatibility.spec.js`. Playwright is aligned to 1.62.1; its Chromium 151 satisfies Foundry 14's minimum Chromium 146. The previous pinned test runner downloaded Chromium 141, which is unsupported. Software WebGL is configured for WSL/CI.
+
+The integration scenarios cover all seven narrative dice, standard and mixed pools, automatic symbols and cancellation, serialization, deferred messages, and actual public/GM/blind/self visibility in separate player and GM sessions, including reloads. They also exercise the five actor types, item sheets and talent trees, Force effect phases and persistence, once-per-roll and combat effect expiration, hidden initiative, combat slot claims and turn progression, and destiny rolls and pool synchronization across two clients.
+
+The complete integration suite passed **27/27 in 4.8 minutes** against the installed development archive on 2026-09-09. The trace inspection found no browser console errors. The archive contains 432 distributable files and was extracted into a separate package directory; the test server loaded that directory instead of the checkout during this run. Its SHA-256 is `1b0974f8f7e51262b4eaca29c49eb59e5f73f168fa80abdc63c4b253e1558949`. The development symlink was restored to the checkout afterward.
+
+The browser fixtures now complete the purchase/grant dialog and close the specific software-rendering warning that otherwise covers sheet controls. Stat checks assert saved-looking field values rather than accidentally filling them; accessory tests require equipping a character's item before its bonuses apply. Failures attach test document data to the Playwright trace for diagnosis.
+
+## Representative v13 world copy
+
+An existing Foundry backup dated 2026-06-11 was restored into the isolated v14 data directory. Its metadata identifies core 13.351 and system 2.0.3. The copied world keeps ID `star-wars` for its asset references, with title **Star Wars v13 Migration Test**. The original Windows world and backup were not modified.
+
+On 2026-09-09, Foundry created an additional backup of the isolated copy and completed its core migration. The copied manifest now records 14.367. The server logged 1,457 migrated Actor records (including the adversary compendium), 91 ChatMessages, 5 FogExplorations and 14 Scenes across five migrated databases, without warnings or errors during that migration. Foundry automatically disabled modules and active scenes as part of the generation upgrade.
+
+The copy reaches the join screen. Its GM account **Grand Moff** requires the user's password, so client initialization, representative existing sheets and persistence after GM login remain unverified. The next step is to sign in to this copy at `http://localhost:30001` using that account. Do not send the password in chat. Assets outside the backed-up world directory are not included in this copy; missing external images must be distinguished from system errors. Optional modules and importers still require separate checks.
 
 ## Runtime acceptance checklist
 
-- [ ] Server starts as 14.367 and loads this checkout's system.
-- [ ] A fresh world initializes without blocking console/server errors.
-- [ ] Character, minion and vehicle creation, editing, item drops and persistence work.
-- [ ] All seven narrative dice, standard dice, mixed pools, automatic symbols, cancellation and serialization work.
-- [ ] Public, GM, blind and self rolls have the correct visibility in separate MJ/player sessions, including after reload.
-- [ ] Initiative for hidden combatants stays private; combat creation, slot claims and turn progression work.
-- [ ] Destiny point rolls, spending and synchronization work across clients.
-- [ ] Effects on actors/items apply correctly, preserve phases/priorities, display durations and expire as expected.
-- [ ] Existing Playwright effect tests pass in the disposable world.
-- [ ] A copy of a representative v13 world migrates and persists correctly; source world remains untouched.
+- [x] Server starts as 14.367 and loads this checkout's system.
+- [x] A fresh world initializes without blocking console/server errors.
+- [x] Character, minion and vehicle creation, editing, item drops and persistence work.
+- [x] All seven narrative dice, standard dice, mixed pools, automatic symbols, cancellation and serialization work.
+- [x] Public, GM, blind and self rolls have the correct visibility in separate MJ/player sessions, including after reload.
+- [x] Initiative for hidden combatants stays private; combat creation, slot claims and turn progression work.
+- [x] Destiny point rolls, spending and synchronization work across clients.
+- [x] Effects on actors/items apply correctly, preserve phases/priorities, display durations and expire as expected.
+- [x] Existing Playwright effect tests pass in the disposable world.
+- [x] A representative v13 backup completes core migration and persists the migrated databases; source world remains untouched.
+- [ ] The migrated world initializes in the GM client; existing sheets and subsequent edits persist correctly.
 - [ ] Importers and supported optional module integrations are checked separately.
-- [ ] A packaged archive installs and reproduces the verified behavior.
+- [x] A packaged archive installs and reproduces the verified behavior.
 
 Update `compatibility.verified`, the release version and the fork's download URLs only after runtime acceptance. No release has been published.
 

--- a/docs/foundry-v14.md
+++ b/docs/foundry-v14.md
@@ -6,7 +6,7 @@
 - Starting commit: `a0a0b546e6171551bf37c55e2420eaafc0a04e56`.
 - Target runtime: Foundry VTT 14.367 (stable), checked 2026-09-09.
 - Existing Windows runtime: Foundry VTT 13.351, serving the live `Star Wars` world on port 30000.
-- Current status: **27/27 integration tests pass against the installed development archive**, and **18/18 isolated compatibility tests pass**. The representative v13 backup completed core migration to 14.367. Its client acceptance awaits a GM login; full compatibility is **not yet verified**.
+- Current status: **27/27 integration tests pass against the installed development archive**, and **18/18 isolated compatibility tests pass**. The representative v13 backup completed core migration to 14.367 and now opens in the GM client. Acceptance checks on existing documents remain in progress; full compatibility is **not yet verified**.
 - Manifest: minimum 13, verified 13, maximum 14. Maximum permits development testing; it is not a verification claim.
 
 ## Changes prepared
@@ -100,7 +100,9 @@ An existing Foundry backup dated 2026-06-11 was restored into the isolated v14 d
 
 On 2026-09-09, Foundry created an additional backup of the isolated copy and completed its core migration. The copied manifest now records 14.367. The server logged 1,457 migrated Actor records (including the adversary compendium), 91 ChatMessages, 5 FogExplorations and 14 Scenes across five migrated databases, without warnings or errors during that migration. Foundry automatically disabled modules and active scenes as part of the generation upgrade.
 
-The copy reaches the join screen. Its GM account **Grand Moff** requires the user's password, so client initialization, representative existing sheets and persistence after GM login remain unverified. The next step is to sign in to this copy at `http://localhost:30001` using that account. Do not send the password in chat. Assets outside the backed-up world directory are not included in this copy; missing external images must be distinguished from system errors. Optional modules and importers still require separate checks.
+The user signed in with the GM account and the migrated client initializes, displaying existing actors, scenes and historical chat rolls. The first view showed missing portraits, tokens and scene backgrounds because media outside the world backup had not been copied. The `assets/Star Wars`, `assets/Misc` and `worlds/star-wars/assets` media directories were copied from the Windows installation into the isolated data directory: 903 files (442,367,180 bytes) were added and verified by SHA-256, while 13 existing files were retained. The Windows source files were not modified. A fresh client view now renders the Mos Zandari background correctly.
+
+The world database remains the 2026-06-11 backup; copying current media does not update it to the latest live campaign state. The existing Dodge character sheet opens with its portrait, characteristics, skills, species, career and specializations. Broader existing-document checks and persistence of subsequent edits remain outstanding. Optional modules and importers require separate checks.
 
 ## Runtime acceptance checklist
 
@@ -114,7 +116,8 @@ The copy reaches the join screen. Its GM account **Grand Moff** requires the use
 - [x] Effects on actors/items apply correctly, preserve phases/priorities, display durations and expire as expected.
 - [x] Existing Playwright effect tests pass in the disposable world.
 - [x] A representative v13 backup completes core migration and persists the migrated databases; source world remains untouched.
-- [ ] The migrated world initializes in the GM client; existing sheets and subsequent edits persist correctly.
+- [x] The migrated world initializes in the GM client and an existing character sheet opens with its data and portrait.
+- [ ] Broader existing-document checks and persistence of subsequent edits pass in the migrated world.
 - [ ] Importers and supported optional module integrations are checked separately.
 - [x] A packaged archive installs and reproduces the verified behavior.
 

--- a/docs/foundry-v14.md
+++ b/docs/foundry-v14.md
@@ -1,0 +1,95 @@
+# Foundry VTT 14 migration
+
+## Target and status
+
+- Branch: `misterWhite-foundry-v14`.
+- Starting commit: `a0a0b546e6171551bf37c55e2420eaafc0a04e56`.
+- Target runtime: Foundry VTT 14.367 (stable), checked 2026-09-08.
+- Existing Windows runtime: Foundry VTT 13.351, serving the live `Star Wars` world on port 30000.
+- Current status: initial source adaptations and isolated tests only. **Not yet validated in Foundry 14.**
+- Manifest: minimum 13, verified 13, maximum 14. Maximum permits development testing; it is not a verification claim.
+
+## Changes prepared
+
+Chat creation uses `author` and `style`. Chat rendering listens for `renderChatMessageHTML` and adapts its HTMLElement to the existing jQuery handlers. The dice audio call uses the namespaced AudioHelper.
+
+The roll boundary selects the correct core setting and API for v13/v14, accepts older macro roll-mode arguments, and returns plain document data for `create: false`. Initiative hides otherwise-public rolls for hidden combatants. The group manager uses the current private roll option for obligation/duty triggers.
+
+Active Effect creation uses string change types on v14 and numeric modes on v13. Rank updates retain a change's type, phase and priority. The Actor override forwards the application phase. The sheet reads duration labels from v14's prepared effect, and the combat tracker reads actor effects rather than removed token fields.
+
+The public Karlinator fork was examined as a reference. Its changes are not merged: its manifest claim does not establish coverage of dice, message privacy or effects for this newer upstream checkout.
+
+## Validation performed
+
+`npm run compile` succeeds on the starting checkout. Its generated CSS differs from the checked-in file; that unrelated output was not included in this migration.
+
+Initial ESLint baseline: **119 errors and 466 warnings**. The first compatibility pass introduces no additional error messages. Existing errors remain and are not evidence of v14 compatibility.
+
+Run the isolated document-boundary tests with:
+
+```bash
+npm run test:compat
+```
+
+These tests execute the actual system roll and compatibility helpers against stubbed Foundry interfaces. They check mode selection, intended whisper recipients, legacy macro options, deferred message creation, private group rolls and effect change formats. They **do not** establish actual client permissions, rendering, serialization or core data migrations. Those require the runtime checks below.
+
+## Isolated Foundry environment
+
+Use a separate Foundry 14 installation and a separate User Data folder. Do not launch this development system against the live Windows User Data folder. The tests create and delete documents.
+
+The official Node.js distribution ZIP is required. A Node 24.15.0 runtime is already present in WSL; check the downloaded Foundry package's engine requirements before selecting it. Authentication is required on the vendor website to download the archive. Activation/EULA steps, if prompted, must be completed before browser testing.
+
+Proposed WSL locations, to create once the archive is available:
+
+```text
+/home/tonio2581/foundry-v14/          Application files
+/home/tonio2581/foundry-v14-data/     Disposable development data
+```
+
+Use port 30001 if available. Link `Data/systems/starwarsffg` in the development data folder to the repository. Create a world with:
+
+```text
+ID:    starwarsffg-v14-test
+Title: Star Wars FFG v14 Test
+MJ:    Gamemaster
+```
+
+Create a separate player account for permission checks. Begin with no add-on modules.
+
+Copy `.env.example` to `.env` and set the actual test server URL. Browser setup checks the title/version before joining and checks the world ID, system and generation after joining. The title/version check is deliberately before GM login because login can itself trigger system migration.
+
+After preparing the browser runtime and launching the disposable world:
+
+```bash
+npm run test:e2e -- --trace on
+```
+
+The existing browser tests and login locators were built for v13. The world checks are prepared, but v14 interface adaptations and execution remain outstanding.
+
+Test discovery succeeds: 16 existing Chromium scenarios are listed. `test:e2e` invokes the CLI bundled with `@playwright/test` so that the runner and fixtures share a version; the original dependency tree also contains a different standalone Playwright version. Discovery does not execute the scenarios.
+
+## Runtime acceptance checklist
+
+- [ ] Server starts as 14.367 and loads this checkout's system.
+- [ ] A fresh world initializes without blocking console/server errors.
+- [ ] Character, minion and vehicle creation, editing, item drops and persistence work.
+- [ ] All seven narrative dice, standard dice, mixed pools, automatic symbols, cancellation and serialization work.
+- [ ] Public, GM, blind and self rolls have the correct visibility in separate MJ/player sessions, including after reload.
+- [ ] Initiative for hidden combatants stays private; combat creation, slot claims and turn progression work.
+- [ ] Destiny point rolls, spending and synchronization work across clients.
+- [ ] Effects on actors/items apply correctly, preserve phases/priorities, display durations and expire as expected.
+- [ ] Existing Playwright effect tests pass in the disposable world.
+- [ ] A copy of a representative v13 world migrates and persists correctly; source world remains untouched.
+- [ ] Importers and supported optional module integrations are checked separately.
+- [ ] A packaged archive installs and reproduces the verified behavior.
+
+Update `compatibility.verified`, the release version and the fork's download URLs only after runtime acceptance. No release has been published.
+
+## Primary references
+
+- [Foundry 14.367](https://foundryvtt.com/releases/14.367)
+- [v14 removals](https://github.com/foundryvtt/foundryvtt/issues/13436)
+- [ChatMessage API](https://foundryvtt.com/api/v14/classes/foundry.documents.ChatMessage.html)
+- [Roll API](https://foundryvtt.com/api/v14/classes/foundry.dice.Roll.html)
+- [Active Effect change types](https://foundryvtt.com/api/v14/variables/CONST.ACTIVE_EFFECT_CHANGE_TYPES.html)
+- [Actor effect phases](https://foundryvtt.com/api/v14/classes/foundry.documents.Actor.html#applyActiveEffects)

--- a/e2e/activeEffects.spec.js
+++ b/e2e/activeEffects.spec.js
@@ -2,13 +2,46 @@
 import { test, expect } from '@playwright/test';
 import {Actors, Items} from "../playwright/fixtures";
 
+test.setTimeout(90_000);
+
+// A previous failed run may leave documents behind. Limit cleanup to names used
+// by this suite and require the explicitly configured disposable world.
+const testNames = [
+  'armorActor', 'qa armor', 'qa embeddedArmorActor', 'qa armorItem', 'qa embeddedArmorAttachment', 'qa embeddedMod',
+  'careerActor', 'qa career', 'qa criticalInjuryActor', 'qa criticalInjuryItem',
+  'qa forcePowerActor', 'qa forcePowerItem', 'qa gearActor', 'qa gearItem',
+  'qa signatureAbilityActor', 'qa signatureAbilityItem', 'qa specActor', 'qa specItem',
+  'qa speciesActor', 'qa speciesItem', 'qa talentActor', 'qa talentItem', 'qa weaponActor', 'qa weaponItem',
+  'qa embeddedWeaponActor', 'qa embeddedWeaponItem', 'qa embeddedWeaponAttachment',
+  'qa critActor', 'qa critItem', 'qa attachmentActor', 'qa shipAttachment', 'qa shipWeaponActor',
+  'qa shipWeaponItem', 'qa shipAttActor', 'qa shipAttWpn', 'qa shipAttAtt',
+];
 test.beforeEach(async ({ page }) => {
+  // SwiftShader is intentional in WSL/CI; dismiss this specific persistent notice when it covers a control.
+  await page.addLocatorHandler(page.locator('#notifications .notification').filter({
+    hasText: 'Your web browser does not have hardware acceleration enabled.',
+  }), notice => notice.click());
   await page.goto('/game/');
-  // v13 shows scene loading as a transient progress notification rather than a persistent "Loading"
-  // bar, so wait for the UI to actually be up instead of watching that text come and go. The destiny
-  // tracker is rendered by the system on ready, so it also proves the system finished booting.
   await expect(page.locator('#sidebar')).toBeVisible();
   await expect(page.locator('#destinyDark')).toBeVisible({ timeout: 30_000 });
+  await page.evaluate(async ({ world, names }) => {
+    if (!world || game.world.id !== world) throw new Error('Refusing cleanup outside the test world');
+    for (const [collection, cls] of [[game.actors, game.ffg.ActorFFG], [game.items, game.ffg.ItemFFG]]) {
+      const ids = collection.filter(doc => names.includes(doc.name)).map(doc => doc.id);
+      if (ids.length) await cls.deleteDocuments(ids);
+    }
+  }, { world: process.env.FOUNDRY_TEST_WORLD, names: testNames });
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  if (testInfo.status === testInfo.expectedStatus) return;
+  const documents = await page.evaluate(names => game.actors.filter(a => names.includes(a.name)).map(actor => ({
+    name: actor.name, skills: actor.system.skills, attributes: actor.system.characteristics, stats: actor.system.stats,
+    items: actor.items.map(item => ({ name: item.name, type: item.type, effects: item.effects.map(e => e.toObject()),
+      talents: item.system.talents, upgrades: item.system.upgrades, attributes: item.system.attributes,
+      equippable: item.system.equippable })),
+  })), testNames);
+  await testInfo.attach('effect-documents', { body: JSON.stringify(documents, null, 2), contentType: 'application/json' });
 });
 
 // TODO: most of these tests should be extended to confirm that they still work if they're done while the item is on an actor
@@ -127,6 +160,7 @@ test('force power applies correctly', async ({ page }) => {
 
   // drag and drop onto the character
   await page.getByRole('listitem').filter({ hasText: itemName }).dragTo(page.locator('.character-details-table'));
+  await page.getByRole('button', { name: 'Grant', exact: true }).click();
   await fpActor.switchTab('characteristics');
   await fpActor.checkSkillModifiers('Computers', 'Success', '2');
 
@@ -176,6 +210,7 @@ test('signature ability applies correctly', async ({ page }) => {
 
   // drag and drop onto the character
   await page.getByRole('listitem').filter({ hasText: itemName }).dragTo(page.locator('.character-details-table'));
+  await page.getByRole('button', { name: 'Grant', exact: true }).click();
   await saActor.switchTab('characteristics');
   await saActor.checkSkillModifiers('Medicine', 'Success', '1');
 
@@ -201,6 +236,7 @@ const actorName = "qa specActor";
 
   // drag and drop onto the character
   await page.getByRole('listitem').filter({ hasText: itemName }).dragTo(page.locator('.character-details-table'));
+  await page.getByRole('button', { name: 'Grant', exact: true }).click();
   await spActor.switchTab('characteristics');
   await spActor.checkSkillModifiers('Perception', 'boost', '3');
 
@@ -320,7 +356,6 @@ test('embedded armor applies correctly', async ({ page }) => {
   await embeddedActor.switchTab('gear');
   await embeddedActor.checkStat('soak', '0');
   await page.getByRole('listitem').filter({ hasText: baseItemName }).dragTo(page.locator('.tab.items.active'));
-  // TODO: this should probably be 0, because the AE should not apply until equipped
   await embeddedActor.checkStat('soak', '0');
 
   // okay, add the mod
@@ -332,8 +367,8 @@ test('embedded armor applies correctly', async ({ page }) => {
   await embeddedActor.editItem(baseItemName);
   await page.getByRole('listitem').filter({ hasText: modName }).dragTo(page.locator('.attachments.items'));
   await armor.closeSheet();
-  await embeddedActor.checkStat('defense.melee', '1');
-  await embeddedActor.checkStat('defence.ranged', '0');
+  await embeddedActor.checkStat('defense.melee', '0');
+  await embeddedActor.checkStat('defense.ranged', '0');
   await embeddedActor.checkStat('soak', '0');
 
   // okay, now add the mod to the attachment
@@ -356,7 +391,7 @@ test('embedded armor applies correctly', async ({ page }) => {
   await armor.closeSheet();
   await embeddedActor.equipItem(baseItemName);
   await embeddedActor.checkStat('defense.melee', '2');
-  await embeddedActor.checkStat('defence.ranged', '0');
+  await embeddedActor.checkStat('defense.ranged', '0');
 
   // clean up
   await embeddedActor.remove();
@@ -389,8 +424,8 @@ test('embedded weapons applies correctly', async ({ page }) => {
   await embeddedActor.switchTab('gear');
   await embeddedActor.checkStat('soak', '0');
   await page.getByRole('listitem').filter({ hasText: baseItemName }).dragTo(page.locator('.tab.items.active'));
-  // TODO: this should probably be 0, because the AE should not apply until equipped
-  await embeddedActor.checkStat('soak', '1');
+  // Attachment effects stay inactive until the weapon is equipped.
+  await embeddedActor.checkStat('soak', '0');
 
   // create the mod
   const weaponMod = new Items(page, modName, "itemmodifier");
@@ -404,9 +439,9 @@ test('embedded weapons applies correctly', async ({ page }) => {
   // add the mod to the weapon
   await page.getByRole('listitem').filter({ hasText: modName }).dragTo(page.locator('.attachments.items'));
   await weapon.closeSheet();
-  await embeddedActor.checkStat('defense.melee', '1');
-  await embeddedActor.checkStat('defence.ranged', '0');
-  await embeddedActor.checkStat('soak', '1');
+  await embeddedActor.checkStat('defense.melee', '0');
+  await embeddedActor.checkStat('defense.ranged', '0');
+  await embeddedActor.checkStat('soak', '0');
 
   // okay, now add the mod to the attachment
   await embeddedActor.editItem(baseItemName);
@@ -430,7 +465,7 @@ test('embedded weapons applies correctly', async ({ page }) => {
   await embeddedActor.equipItem(baseItemName);
   // validate tha the second mod instance is adding to the AE properly
   await embeddedActor.checkStat('defense.melee', '2');
-  await embeddedActor.checkStat('defence.ranged', '0');
+  await embeddedActor.checkStat('defense.ranged', '0');
 
   // clean up
   await embeddedActor.remove();

--- a/e2e/runtimeCompatibility.spec.js
+++ b/e2e/runtimeCompatibility.spec.js
@@ -1,0 +1,354 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.addLocatorHandler(page.locator('#notifications .notification').filter({
+    hasText: 'Your web browser does not have hardware acceleration enabled.',
+  }), notice => notice.click());
+  await page.goto('/game');
+  await expect(page.locator('#destinyDark')).toBeVisible({ timeout: 30_000 });
+  const identity = await page.evaluate(() => ({ world: game.world.id, system: game.system.id, isGM: game.user.isGM }));
+  expect(identity).toEqual({ world: process.env.FOUNDRY_TEST_WORLD, system: 'starwarsffg', isGM: true });
+});
+
+test('runtime: all narrative dice, standard dice and mixed pools serialize', async ({ page }) => {
+  const results = await page.evaluate(async () => {
+    const output = [];
+    for (const formula of ['1da', '1db', '1dc', '1di', '1df', '1dp', '1ds', '1d6 + 2', '1da + 1d6', 'apd']) {
+      try {
+        const roll = new game.ffg.RollFFG(formula);
+        await roll.evaluate({ maximize: true });
+        const restored = game.ffg.RollFFG.fromData(JSON.parse(JSON.stringify(roll)));
+        output.push({ formula, total: roll.total, ffg: roll.ffg, restored: restored.ffg,
+          restoredTotal: restored.total, dice: roll.dice.map(d => ({ faces: d.faces, results: d.results.length })) });
+      } catch (error) { output.push({ formula, error: String(error) }); }
+    }
+    return output;
+  });
+  expect(results.filter(r => r.error)).toEqual([]);
+  for (const result of results) {
+    expect(result.restored).toEqual(result.ffg);
+    expect(result.restoredTotal).toEqual(result.total);
+    expect(Object.values(result.ffg).every(Number.isFinite)).toBe(true);
+    expect(result.dice.every(d => d.results === 1)).toBe(true);
+  }
+  expect(results.find(r => r.formula === '1d6 + 2').total).toBe(8);
+  expect(results.find(r => r.formula === '1da + 1d6').total).toBe(6);
+});
+
+test('runtime: current chat modes and legacy options set actual document visibility', async ({ page }) => {
+  const results = await page.evaluate(async () => {
+    const previous = game.settings.get('core', 'messageMode');
+    const before = game.messages.size;
+    const output = [];
+    try {
+      await game.settings.set('core', 'messageMode', 'blind');
+      for (const mode of ['public', 'gm', 'blind', 'self', 'publicroll', 'roll']) {
+        const roll = await new game.ffg.RollFFG('1da').evaluate({ maximize: true });
+        const data = await roll.toMessage({}, { messageMode: mode, create: false });
+        output.push({ mode, whisper: data.whisper, blind: data.blind, author: data.author });
+      }
+      return { output, author: game.user.id, gms: game.users.filter(u => u.isGM).map(u => u.id),
+        messagesAdded: game.messages.size - before };
+    } finally { await game.settings.set('core', 'messageMode', previous); }
+  });
+  expect(results.messagesAdded).toBe(0);
+  for (const result of results.output) {
+    expect(result.author).toBe(results.author);
+    expect(result.whisper).toEqual(['public', 'publicroll'].includes(result.mode) ? []
+      : result.mode === 'self' ? [results.author] : results.gms);
+    expect(result.blind).toBe(['blind', 'roll'].includes(result.mode));
+  }
+});
+
+test('runtime: automatic symbols cancel correctly and survive serialization', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const pool = new DicePoolFFG({ success: 3, failure: 1, advantage: 2, threat: 3,
+      triumph: 1, despair: 1, light: 1, dark: 2 });
+    // The first ability-die face is blank, leaving only the automatic symbols.
+    const roll = await new game.ffg.RollFFG('1da', {}, pool).evaluate({ minimize: true });
+    return { symbols: roll.ffg, restored: game.ffg.RollFFG.fromData(JSON.parse(JSON.stringify(roll))).ffg };
+  });
+  expect(result.symbols).toEqual({ success: 2, failure: 0, advantage: 0, threat: 1,
+    triumph: 1, despair: 1, light: 1, dark: 2 });
+  expect(result.restored).toEqual(result.symbols);
+});
+
+test('runtime: character, minion, rival, nemesis and vehicle sheets persist edits', async ({ page }) => {
+  const ids = [];
+  try {
+    for (const type of ['character', 'minion', 'rival', 'nemesis', 'vehicle']) {
+      const id = await page.evaluate(async type => {
+        const actor = await game.ffg.ActorFFG.create({ name: `Runtime ${type} persistence`, type });
+        const stat = type === 'vehicle' ? 'hullTrauma' : 'wounds';
+        await actor.update({ [`system.stats.${stat}.max`]: 20, [`system.stats.${stat}.value`]: 3 });
+        await actor.sheet.getData();
+        return actor.id;
+      }, type);
+      ids.push(id);
+    }
+    await page.reload();
+    await expect(page.locator('#destinyDark')).toBeVisible({ timeout: 30_000 });
+    const saved = await page.evaluate(ids => ids.map(id => {
+      const actor = game.actors.get(id);
+      const stat = actor.type === 'vehicle' ? 'hullTrauma' : 'wounds';
+      return actor.toObject().system.stats[stat].value;
+    }), ids);
+    expect(saved).toEqual([3, 3, 3, 3, 3]);
+  } finally {
+    await page.evaluate(async ids => { await game.ffg.ActorFFG.deleteDocuments(ids); }, ids);
+  }
+});
+
+test('runtime: active effect source data renders with v14 phases and duration', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const { default: EffectHelpers } = await import('/systems/starwarsffg/modules/helpers/effects.js');
+    const actor = new game.ffg.ActorFFG({ name: 'Transient runtime effect test', type: 'character' });
+    const effect = new game.ffg.ActiveEffectFFG({ name: 'Runtime defense',
+      duration: { value: 2, units: 'rounds' },
+      system: { changes: [{ key: 'system.stats.defence.ranged', type: 'add', phase: 'initial', value: 1, priority: 20 }] }
+    }, { parent: actor });
+    const before = JSON.stringify(effect.toObject());
+    const display = EffectHelpers.transformEffects(effect);
+    return { display, unchanged: before === JSON.stringify(effect.toObject()) };
+  });
+  expect(result.unchanged).toBe(true);
+  expect(result.display.changes[0]).toMatchObject({ key: 'stats.defence.ranged', mode: 'ADD', phase: 'initial', priority: 20 });
+  expect(typeof result.display.duration).toBe('string');
+});
+
+test('runtime: item sheets prepare without traversing circular Document references', async ({ page }) => {
+  const failures = await page.evaluate(async () => {
+    const failures = [];
+    for (const type of ['armour', 'weapon', 'gear', 'itemattachment', 'itemmodifier', 'talent', 'forcepower', 'signatureability', 'specialization']) {
+      const item = new game.ffg.ItemFFG({ name: `Transient ${type}`, type });
+      try {
+        const data = await item.sheet.getData();
+        const tree = data.item.system.upgrades ?? data.item.system.talents;
+        if (tree && Object.values(tree).some(node => node.visible !== true)) throw new Error('Tree was not prepared before the sheet snapshot');
+      }
+      catch (error) { failures.push({ type, error: error.stack }); }
+    }
+    return failures;
+  });
+  expect(failures).toEqual([]);
+});
+
+test('runtime: player and GM see the correct roll content, including after reload', async ({ page, browser }) => {
+  test.setTimeout(150_000);
+  // Override Playwright's project storageState: the player must get a new server session.
+  const playerContext = await browser.newContext({ storageState: { cookies: [], origins: [] }, viewport: { width: 1440, height: 900 } });
+  const playerPage = await playerContext.newPage();
+  const ids = [];
+  try {
+    await playerPage.goto(new URL('/join', process.env.FOUNDRY_URL).href);
+    await expect(playerPage.locator('#main-header h1')).toHaveText(process.env.FOUNDRY_TEST_WORLD_TITLE);
+    await playerPage.getByRole('textbox', { name: 'Select User', exact: true }).click();
+    await playerPage.getByRole('listitem').filter({ hasText: /^Player2$/ }).click();
+    await playerPage.getByRole('button', { name: 'Join Game Session', exact: true }).click();
+    await expect.poll(() => playerPage.evaluate(() => typeof game !== 'undefined' && !!game.ready).catch(() => false), { timeout: 60_000 }).toBe(true);
+    const playerConfiguration = playerPage.getByRole('button', { name: 'Save Player Configuration', exact: true });
+    if (await playerConfiguration.isVisible()) await playerConfiguration.click();
+    expect(await playerPage.evaluate(() => ({ name: game.user.name, isGM: game.user.isGM })))
+      .toEqual({ name: 'Player2', isGM: false });
+    expect(await page.evaluate(() => game.user.isGM)).toBe(true);
+    for (const mode of ['public', 'gm', 'blind', 'self']) {
+      const id = await playerPage.evaluate(async mode => {
+        const roll = await new game.ffg.RollFFG('1da').evaluate({ maximize: true });
+        return (await roll.toMessage({ flavor: `Runtime visibility ${mode}` }, { messageMode: mode })).id;
+      }, mode);
+      ids.push(id);
+      await expect.poll(() => page.evaluate(id => !!game.messages.get(id), id)).toBe(true);
+      const playerContent = await playerPage.evaluate(id => game.messages.get(id).isContentVisible, id);
+      const gmContent = await page.evaluate(id => game.messages.get(id).isContentVisible, id);
+      expect(playerContent, `${mode}: player visibility`).toBe(mode !== 'blind');
+      expect(gmContent, `${mode}: GM visibility`).toBe(mode !== 'self');
+    }
+    await playerPage.reload();
+    await expect.poll(() => playerPage.evaluate(() => typeof game !== 'undefined' && !!game.ready).catch(() => false), { timeout: 60_000 }).toBe(true);
+    const visibility = await playerPage.evaluate(ids => ids.map(id => game.messages.get(id)?.isContentVisible), ids);
+    expect(visibility).toEqual([true, true, false, true]);
+    const blindMessage = playerPage.locator(`[data-message-id="${ids[2]}"]`);
+    await expect(blindMessage).not.toContainText('Successes:');
+  } catch (error) {
+    console.log('Player page at failure:', await playerPage.locator('body').innerText({ timeout: 3000 }).catch(() => 'Unavailable'));
+    throw error;
+  } finally {
+    await playerContext.close();
+    await page.evaluate(async ids => {
+      const remaining = ids.filter(id => game.messages.has(id));
+      if (remaining.length) await ChatMessage.deleteDocuments(remaining);
+    }, ids);
+  }
+});
+
+test('runtime: Force bonuses and final-phase effects persist without double application', async ({ page }) => {
+  const id = await page.evaluate(async () => {
+    const actor = await game.ffg.ActorFFG.create({ name: 'Runtime Force phase test', type: 'character' });
+    await actor.update({ 'system.stats.forcePool.max': 2, 'system.stats.forcePool.value': 1 });
+    await actor.createEmbeddedDocuments('ActiveEffect', [
+      { name: 'Force Rating', system: { changes: [{ key: 'system.stats.forcePool.max', type: 'add', value: 1 }] } },
+      { name: 'Disabled Force Rating', disabled: true, system: { changes: [{ key: 'system.stats.forcePool.max', type: 'add', value: 5 }] } },
+      { name: 'Force skill', system: { changes: [{ key: 'system.skills.Discipline.force', type: 'add', value: 0 }] } },
+      { name: 'Final defense', system: { changes: [{ key: 'system.stats.defence.ranged', type: 'add', value: 2, phase: 'final', priority: 20 }] } },
+    ]);
+    return actor.id;
+  });
+  try {
+    const readStats = () => page.evaluate(id => {
+      const actor = game.actors.get(id);
+      return { max: actor.system.stats.forcePool.max, force: actor.system.skills.Discipline.force,
+        defense: actor.system.stats.defence.ranged };
+    }, id);
+    expect(await readStats()).toEqual({ max: 3, force: 2, defense: 2 });
+    await page.reload();
+    await expect(page.locator('#destinyDark')).toBeVisible({ timeout: 30_000 });
+    expect(await readStats()).toEqual({ max: 3, force: 2, defense: 2 });
+    await page.evaluate(async id => {
+      await game.actors.get(id).effects.find(e => e.name === 'Force Rating').update({ disabled: true });
+    }, id);
+    expect(await readStats()).toEqual({ max: 2, force: 1, defense: 2 });
+  } finally {
+    await page.evaluate(async id => { await game.actors.get(id)?.delete(); }, id);
+  }
+});
+
+test('runtime: system status durations survive the v14 ActiveEffect data model', async ({ page }) => {
+  const id = await page.evaluate(async () => {
+    const actor = await game.ffg.ActorFFG.create({ name: 'Runtime expiring effects', type: 'character' });
+    await actor.createEmbeddedDocuments('ActiveEffect', ['once', 'combat'].map(duration => ({
+      name: `Runtime ${duration} effect`, system: { duration },
+      changes: [{ key: 'system.skills.Discipline.boost', type: 'add', value: 1 }],
+    })));
+    return actor.id;
+  });
+  try {
+    const readDurations = () => page.evaluate(id => game.actors.get(id).effects.map(effect => ({
+      prepared: effect.system.duration, saved: effect.toObject().system.duration,
+    })).sort((a, b) => a.prepared.localeCompare(b.prepared)), id);
+    const expected = [{ prepared: 'combat', saved: 'combat' }, { prepared: 'once', saved: 'once' }];
+    expect(await readDurations()).toEqual(expected);
+    await page.reload();
+    await expect(page.locator('#destinyDark')).toBeVisible({ timeout: 30_000 });
+    expect(await readDurations()).toEqual(expected);
+    await page.evaluate(id => {
+      const actor = game.actors.get(id);
+      new game.ffg.RollBuilderFFG({ document: actor, actor: actor.toObject() },
+        new DicePoolFFG({ boost: 1 }), 'Runtime expiry roll', 'Discipline').render(true);
+    }, id);
+    await page.locator('#roll-builder .roll-button .btn').click();
+    await expect.poll(readDurations).toEqual([{ prepared: 'combat', saved: 'combat' }]);
+    await page.evaluate(async () => {
+      await Object.values(ui.windows).find(app => app.id === 'roll-builder')?.close();
+    });
+  } finally {
+    await page.evaluate(async id => {
+      const messages = game.messages.filter(m => m.speaker.actor === id).map(m => m.id);
+      if (messages.length) await ChatMessage.deleteDocuments(messages);
+      await game.actors.get(id)?.delete();
+    }, id);
+  }
+});
+
+test('runtime: hidden initiative remains private and combat advances', async ({ page }) => {
+  test.setTimeout(90_000);
+  const created = await page.evaluate(async () => {
+    const actor = await game.ffg.ActorFFG.create({ name: 'Runtime hidden combatant', type: 'character' });
+    await actor.update({ 'system.characteristics.Willpower.value': 2 });
+    await actor.createEmbeddedDocuments('ActiveEffect', [{ name: 'Runtime combat effect',
+      system: { duration: 'combat' } }]);
+    const scene = await Scene.create({ name: 'Runtime combat scene', width: 1000, height: 1000,
+      tokens: [{ name: actor.name, actorId: actor.id, actorLink: true, hidden: true, x: 200, y: 200 }] });
+    await scene.activate();
+    await scene.view();
+    const combat = await game.ffg.CombatFFG.create({ scene: scene.id, active: true });
+    const [combatant] = await combat.createEmbeddedDocuments('Combatant', [{ actorId: actor.id,
+      tokenId: scene.tokens.contents[0].id, sceneId: scene.id, hidden: true }]);
+    return { actor: actor.id, scene: scene.id, combat: combat.id, combatant: combatant.id };
+  });
+  try {
+    await page.evaluate(({ combat, combatant }) => {
+      void game.combats.get(combat).rollInitiative([combatant], { messageOptions: { messageMode: 'public' } });
+    }, created);
+    await page.getByRole('button', { name: 'Rolling Initiative', exact: true }).click();
+    await expect.poll(() => page.evaluate(({ combat, combatant }) =>
+      game.combats.get(combat).combatants.get(combatant).initiative, created)).not.toBe(null);
+    const message = await page.evaluate(({ actor }) => {
+      const message = game.messages.find(m => m.speaker.actor === actor && m.flags.core?.initiativeRoll);
+      return { whisper: message?.whisper, gms: game.users.filter(u => u.isGM).map(u => u.id) };
+    }, created);
+    expect(message.whisper).toEqual(message.gms);
+    const state = await page.evaluate(async ({ combat, combatant }) => {
+      const encounter = game.combats.get(combat);
+      await encounter.startCombat();
+      await encounter.claimSlot(encounter.round, combatant, combatant);
+      const claim = encounter.getSlotClaims(encounter.round, combatant);
+      await ui.combat.render(true);
+      await encounter.nextTurn();
+      return { round: encounter.round, claim };
+    }, created);
+    expect(state.round).toBeGreaterThanOrEqual(1);
+    expect(state.claim).toBe(created.combatant);
+    await page.evaluate(async ({ combat, combatant }) => {
+      await game.combats.get(combat).combatants.get(combatant).delete();
+    }, created);
+    expect(await page.evaluate(({ actor }) => game.actors.get(actor).effects.size, created)).toBe(0);
+  } finally {
+    await page.evaluate(async ({ actor, scene, combat }) => {
+      const messages = game.messages.filter(m => m.speaker.actor === actor).map(m => m.id);
+      if (messages.length) await ChatMessage.deleteDocuments(messages);
+      await game.combats.get(combat)?.delete();
+      await game.scenes.get(scene)?.delete();
+      await game.actors.get(actor)?.delete();
+    }, created);
+  }
+});
+
+test('runtime: destiny rolls and spending synchronize between player and GM', async ({ page, browser }) => {
+  test.setTimeout(120_000);
+  const previous = await page.evaluate(() => ({ light: game.settings.get('starwarsffg', 'dPoolLight'),
+    dark: game.settings.get('starwarsffg', 'dPoolDark'), messages: game.messages.map(m => m.id) }));
+  const context = await browser.newContext({ storageState: { cookies: [], origins: [] }, viewport: { width: 1440, height: 900 } });
+  try {
+    const player = await context.newPage();
+    await player.goto(new URL('/join', process.env.FOUNDRY_URL).href);
+    await expect(player.locator('#main-header h1')).toHaveText(process.env.FOUNDRY_TEST_WORLD_TITLE);
+    await player.getByRole('textbox', { name: 'Select User', exact: true }).click();
+    await player.getByRole('listitem').filter({ hasText: /^Player2$/ }).click();
+    await player.getByRole('button', { name: 'Join Game Session', exact: true }).click();
+    await expect.poll(() => player.evaluate(() => typeof game !== 'undefined' && !!game.ready).catch(() => false), { timeout: 60_000 }).toBe(true);
+    await page.evaluate(async () => {
+      await game.settings.set('starwarsffg', 'dPoolLight', 2);
+      await game.settings.set('starwarsffg', 'dPoolDark', 1);
+    });
+    const readPool = client => client.evaluate(() => ({ light: game.settings.get('starwarsffg', 'dPoolLight'),
+      dark: game.settings.get('starwarsffg', 'dPoolDark') }));
+    await expect.poll(() => readPool(player)).toEqual({ light: 2, dark: 1 });
+    await player.locator('#destinyLight').click();
+    await expect.poll(() => readPool(page)).toEqual({ light: 1, dark: 2 });
+    await expect.poll(() => readPool(player)).toEqual({ light: 1, dark: 2 });
+    await page.locator('#destinyDark').click();
+    await expect.poll(() => readPool(player)).toEqual({ light: 2, dark: 1 });
+    // The normal GM request button registers the respondent and creates the chat action.
+    await page.locator('#destinyMenu a[data-value="1"]').click();
+    const readRequest = () => page.evaluate(previousIds => game.messages.find(m =>
+      !previousIds.includes(m.id) && m.content.includes('ffg-destiny-roll'))?.id, previous.messages);
+    await expect.poll(readRequest).toBeTruthy();
+    const requestId = await readRequest();
+    await player.getByRole('tab', { name: 'Chat Messages', exact: true }).click();
+    await player.locator(`[data-message-id="${requestId}"] .ffg-destiny-roll:not(#chat-notifications *)`).click({ timeout: 15_000 });
+    await expect.poll(async () => {
+      const pool = await readPool(page);
+      return pool.light + pool.dark;
+    }).toBeGreaterThan(3);
+    await expect.poll(() => readPool(player)).toEqual(await readPool(page));
+  } finally {
+    await page.evaluate(async previous => {
+      await game.settings.set('starwarsffg', 'dPoolLight', previous.light);
+      await game.settings.set('starwarsffg', 'dPoolDark', previous.dark);
+      const ids = game.messages.filter(m => !previous.messages.includes(m.id)).map(m => m.id);
+      if (ids.length) await ChatMessage.deleteDocuments(ids);
+    }, previous);
+    await context.close();
+  }
+});

--- a/modules/active-effects/active-effect-ffg.js
+++ b/modules/active-effects/active-effect-ffg.js
@@ -1,7 +1,7 @@
 ﻿
-function disablePushOnItem(options){
+function disablePushOnItem(effect, options){
   // don't show push/animation if that's an effect from item
-  if(options.parent.parentCollection === "items")
+  if(effect.parent?.documentName === "Item")
   {
     options.animate = false;
   }
@@ -14,19 +14,19 @@ function disablePushOnItem(options){
 export class ActiveEffectFFG extends ActiveEffect {
   /** @override */
   async _onCreate(changed, options, userId) {
-    disablePushOnItem(options);
+    disablePushOnItem(this, options);
     await super._onCreate(changed, options, userId);
   }
 
   /** @override */
   async _onUpdate(changed, options, userId) {
-    disablePushOnItem(options);
+    disablePushOnItem(this, options);
     await super._onUpdate(changed, options, userId);
   }
 
   /** @override */
   async _onDelete(options, userId) {
-    disablePushOnItem(options);
+    disablePushOnItem(this, options);
     await super._onDelete(options, userId);
   }
 }

--- a/modules/actors/actor-ffg.js
+++ b/modules/actors/actor-ffg.js
@@ -548,7 +548,7 @@ export class ActorFFG extends Actor {
     const actorActiveEffects = actorData.getEmbeddedCollection("ActiveEffect");
     for (const effect of actorActiveEffects) {
       for (const change of effect.changes) {
-        if (change.key.includes("system.skills")) {
+        if (change.key?.includes("system.skills")) {
           const skillName = change.key.split('.')[2].capitalize();
           const skillMod = change.key.split('.')[3];
           const modType = ModifierHelpers.getModTypeByModPath(change.key);
@@ -584,7 +584,7 @@ export class ActorFFG extends Actor {
       for (const effect of itemActiveEffects) {
         if (!effect.disabled) {
           for (const change of effect.changes) {
-            if (change.key.includes("system.skills")) {
+            if (change.key?.includes("system.skills")) {
               // system.skills.Astrogation.value
               const skillName = change.key.split('.')[2].capitalize();
               const skillMod = change.key.split('.')[3];
@@ -723,9 +723,12 @@ export class ActorFFG extends Actor {
 
   /** @override **/
   applyActiveEffects(phase) {
+    // v14 calls this again after derived data. Do not count initial bonuses twice.
+    if (phase && phase !== "initial") return super.applyActiveEffects(phase);
     // collect force pool modifications since it appears the stat value is without AEs active
     let maxForceRating = parseInt(this.system?.stats?.forcePool?.max);
     for (const effect of this.allApplicableEffects()) {
+      if (!effect.active) continue;
       for (const change of effect.changes) {
         if (change.key === "system.stats.forcePool.max") {
           maxForceRating += parseInt(change.value);
@@ -734,8 +737,9 @@ export class ActorFFG extends Actor {
     }
     // apply the resulting value (minus any committed dice)
     for (const effect of this.allApplicableEffects()) {
+      if (!effect.active) continue;
       for (const change of effect.changes) {
-        if (change.key.includes("system.skills") && change.key.includes(".force")) {
+        if (change.key?.includes("system.skills") && change.key.includes(".force")) {
           change.value = Math.max(maxForceRating - parseInt(this.system?.stats?.forcePool?.value), 0);
         }
       }

--- a/modules/actors/actor-ffg.js
+++ b/modules/actors/actor-ffg.js
@@ -722,7 +722,7 @@ export class ActorFFG extends Actor {
   }
 
   /** @override **/
-  applyActiveEffects() {
+  applyActiveEffects(phase) {
     // collect force pool modifications since it appears the stat value is without AEs active
     let maxForceRating = parseInt(this.system?.stats?.forcePool?.max);
     for (const effect of this.allApplicableEffects()) {
@@ -740,6 +740,6 @@ export class ActorFFG extends Actor {
         }
       }
     }
-    return super.applyActiveEffects();
+    return super.applyActiveEffects(phase);
   }
 }

--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -67,6 +67,9 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
       const item = await Item.implementation.fromDropData(data);
       // do not Draw values from the underlying data source rather than transformed values - we want to use adjusted values
       const itemData = item.toObject(false);
+      // Keep adjusted item values, but serialize effects from their source data:
+      // v14 prepares a permanent duration as Infinity, which cannot be persisted.
+      if (game.release.generation >= 14) itemData.effects = item.effects.map(effect => effect.toObject());
 
       // Handle item sorting within the same Actor
       if ( this.actor.uuid === item.parent?.uuid ) return this._onSortItem(event, itemData);
@@ -226,6 +229,9 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
 
     data.token = this.token;
     data.items = this.actor.items;
+    await Promise.all(data.items.map(async item => {
+      item.system.renderedDesc = await PopoutEditor.renderDiceImages(item.system.description, this.actor);
+    }));
 
     if (options?.action === "update" && this.object.compendium) {
       data.item = foundry.utils.mergeObject(data.actor, options.data);

--- a/modules/actors/actor-sheet-ffg.js
+++ b/modules/actors/actor-sheet-ffg.js
@@ -1639,8 +1639,8 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
     const html = await foundry.applications.handlebars.renderTemplate(template, { itemDetails, item });
 
     const messageData = {
-      user: game.user.id,
-      type: CONST.CHAT_MESSAGE_STYLES.OTHER,
+      author: game.user.id,
+      style: CONST.CHAT_MESSAGE_STYLES.OTHER,
       content: html,
       speaker: {
         actor: this.actor.id,
@@ -1669,8 +1669,8 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
     const html = await foundry.applications.handlebars.renderTemplate(template, { itemDetails, item });
 
     const messageData = {
-      user: game.user.id,
-      type: CONST.CHAT_MESSAGE_TYPES.OTHER,
+      author: game.user.id,
+      style: CONST.CHAT_MESSAGE_STYLES.OTHER,
       content: html,
       speaker: {
         actor: this.actor.id,
@@ -1845,12 +1845,12 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
       changes: [
         {
           key: boughtPath,
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          ...EffectHelpers.changeType(),
           value: boughtValue,
         },
         {
           key: "system.experience.available",
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          ...EffectHelpers.changeType(),
           value: spentXP * -1,
         }
       ],
@@ -1860,7 +1860,7 @@ export class ActorSheetFFG extends foundry.appv1.sheets.ActorSheet {
     if (boughtPath === "system.characteristics.Brawn.value") {
       effects.changes.push({
         key: "system.stats.soak.value",
-        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        ...EffectHelpers.changeType(),
         value: 1,
       });
     }

--- a/modules/combat-ffg.js
+++ b/modules/combat-ffg.js
@@ -287,7 +287,7 @@ export class CombatFFG extends Combat {
 
                   // Determine the roll mode
                   let messageMode = getMessageMode(messageOptions);
-                  if ((c.token.hidden || c.hidden) && ["roll", "ic", "ooc"].includes(messageMode)) messageMode = "gm";
+                  if ((c.token.hidden || c.hidden) && ["public", "ic"].includes(messageMode)) messageMode = "gm";
 
                   // Construct chat message data
                   let messageData = foundry.utils.mergeObject(

--- a/modules/combat-ffg.js
+++ b/modules/combat-ffg.js
@@ -1,3 +1,4 @@
+import { getMessageMode } from "./helpers/chat.js";
 import {DicePoolFFG, RollFFG} from "./dice-pool-ffg.js";
 import PopoutEditor from "./popout-editor.js";
 
@@ -285,8 +286,8 @@ export class CombatFFG extends Combat {
                   updates.push({ _id: id, initiative: roll.total });
 
                   // Determine the roll mode
-                  let rollMode = messageOptions.rollMode || game.settings.get("core", "rollMode");
-                  if ((c.token.hidden || c.hidden) && rollMode === "roll") rollMode = "gmroll";
+                  let messageMode = getMessageMode(messageOptions);
+                  if ((c.token.hidden || c.hidden) && ["roll", "ic", "ooc"].includes(messageMode)) messageMode = "gm";
 
                   // Construct chat message data
                   let messageData = foundry.utils.mergeObject(
@@ -302,7 +303,7 @@ export class CombatFFG extends Combat {
                     },
                     messageOptions
                   );
-                  const chatData = await roll.toMessage(messageData, { create: false, rollMode });
+                  const chatData = await roll.toMessage(messageData, { create: false, messageMode });
 
                   // Play 1 sound for the whole rolled set
                   if (i > 0) chatData.sound = null;
@@ -821,20 +822,13 @@ export class CombatFFG extends Combat {
         let defeated = claimant.isDefeated;
 
         const effects = new Set();
-        if (claimant.token) {
-          claimant.token.effects.forEach((e) => effects.add(e))
-          if (claimant.token.overlayEffect) {
-            effects.add(claimant.token.overlayEffect);
-          }
-        }
-
         if (claimant.actor) {
           if (claimant.isDefeated) {
             defeated = true;
           }
           for (const effect of claimant.actor.temporaryEffects) {
-            if (effect?.icon) {
-              effects.add(effect.icon);
+            if (effect?.img) {
+              effects.add(effect.img);
             }
           }
         }

--- a/modules/dice/roll-builder.js
+++ b/modules/dice/roll-builder.js
@@ -215,7 +215,7 @@ export default class RollBuilderFFG extends FormApplication {
         </div>`;
 
         let chatOptions = {
-          user: game.user.id,
+          author: game.user.id,
           content: messageText,
           flags: {
             starwarsffg: {
@@ -241,7 +241,7 @@ export default class RollBuilderFFG extends FormApplication {
           await this.roll.item.update({"flags": {"starwarsffg": {"crew": this.roll.item.crew}}})
         }
         await roll.toMessage({
-          user: game.user.id,
+          author: game.user.id,
           speaker: {
             actor: game.actors.get(this.roll.data?.actor?._id),
             alias: this.roll.data?.token?.name,
@@ -250,7 +250,7 @@ export default class RollBuilderFFG extends FormApplication {
           flavor: `${game.i18n.localize("SWFFG.Rolling")} ${game.i18n.localize(this.roll.skillName)}...`,
         });
         if (this.roll?.sound) {
-          AudioHelper.play({ src: this.roll.sound }, true);
+          foundry.audio.AudioHelper.play({ src: this.roll.sound }, true);
         }
 
         return roll;

--- a/modules/dice/roll.js
+++ b/modules/dice/roll.js
@@ -2,6 +2,7 @@ import PopoutEditor from "../popout-editor.js";
 import { ForceDie } from "./dietype/ForceDie.js";
 import {migrateDataToSystem} from "../helpers/migration.js";
 import {ItemFFG} from "../items/item-ffg.js";
+import { applyMessageMode, getMessageMode } from "../helpers/chat.js";
 
 /**
  * New extension of the core DicePool class for evaluating rolls with the FFG DiceTerms
@@ -342,27 +343,28 @@ export class RollFFG extends Roll {
 
   /* -------------------------------------------- */
   /** @override */
-  async toMessage(messageData = {}, { rollMode = null, create = true } = {}) {
+  async toMessage(messageData = {}, { messageMode, rollMode, create = true } = {}) {
     // Perform the roll, if it has not yet been rolled
     if (!this._evaluated) await this.evaluate();
 
-    const rMode = rollMode || messageData.rollMode || game.settings.get("core", "rollMode");
-
-    if (["gmroll", "blindroll"].includes(rMode)) {
-      messageData.whisper = ChatMessage.getWhisperRecipients("GM");
-    }
-    if (rMode === "blindroll") messageData.blind = true;
-    if (rMode === "selfroll") messageData.whisper = [game.user.id];
+    const mode = getMessageMode({
+      messageMode: messageMode ?? rollMode ?? messageData.messageMode ?? messageData.rollMode,
+    });
 
     // Prepare chat data
     messageData = foundry.utils.mergeObject(
       {
-        user: game.user.id,
+        author: game.user.id,
         content: this.total,
         sound: CONFIG.sounds.dice,
       },
       messageData
     );
+    // Accept older macro data, but only pass current document fields to Foundry.
+    if (messageData.user) messageData.author = messageData.user;
+    delete messageData.user;
+    delete messageData.rollMode;
+    delete messageData.messageMode;
     messageData.rolls = [this];
 
     Hooks.call("ffgDiceMessage", this);
@@ -370,10 +372,11 @@ export class RollFFG extends Roll {
     // Either create the message or just return the chat data
     const cls = getDocumentClass("ChatMessage");
     const msg = new cls(messageData);
-    if (rMode) msg.applyRollMode(rMode);
+    if (mode) applyMessageMode(msg, mode);
 
     // Either create or return the data
-    return create ? await cls.create(msg) : msg;
+    const data = msg.toObject();
+    return create ? await cls.create(data) : data;
   }
 
   /** @override */

--- a/modules/ffg-destiny-tracker.js
+++ b/modules/ffg-destiny-tracker.js
@@ -160,7 +160,7 @@ export default class DestinyTracker extends FormApplication {
       }
 
       ChatMessage.create({
-        user: game.user.id,
+        author: game.user.id,
         content: messageText,
       });
     });
@@ -169,8 +169,8 @@ export default class DestinyTracker extends FormApplication {
     $(".ffg-destiny-roll").on("click", this.OnClickRollDestiny.bind(this));
 
     // setup chat hook for destiny roll
-    Hooks.on("renderChatMessage", (app, html, messageData) => {
-      html.on("click", ".ffg-destiny-roll", this.OnClickRollDestiny.bind(this));
+    Hooks.on("renderChatMessageHTML", (message, html) => {
+      $(html).on("click", ".ffg-destiny-roll", this.OnClickRollDestiny.bind(this));
     });
 
     // setup socket handler for checking destiny roll
@@ -307,7 +307,7 @@ export default class DestinyTracker extends FormApplication {
 
     const roll = new game.ffg.RollFFG(pool.renderDiceExpression());
     await roll.toMessage({
-      user: game.user.id,
+      author: game.user.id,
       flavor: `${game.i18n.localize("SWFFG.Rolling")} ${game.i18n.localize("SWFFG.DestinyPool")}...`,
     });
 

--- a/modules/groupmanager-ffg.js
+++ b/modules/groupmanager-ffg.js
@@ -1,3 +1,4 @@
+import { getRollMessageOptions } from "./helpers/chat.js";
 import {xpLogEarn} from "./helpers/actor-helpers.js";
 import ActorHelpers from "./helpers/actor-helpers.js";
 
@@ -275,7 +276,7 @@ export class GroupManager extends FormApplication {
   async _rollTable(table, type) {
     let r = new Roll("1d100");
     await r.evaluate();
-    let rollOptions = game.settings.get("starwarsffg", "privateTriggers") ? { rollMode: "gmroll" } : {};
+    const rollOptions = game.settings.get("starwarsffg", "privateTriggers") ? getRollMessageOptions("gm") : {};
     r.toMessage(
       {
         flavor: `${game.i18n.localize("SWFFG.Rolling")} ${type}...`,
@@ -285,7 +286,7 @@ export class GroupManager extends FormApplication {
     let filteredTable = table.filter((entry) => entry.rangeStart <= r.total && r.total <= entry.rangeEnd);
     let tableResult = filteredTable?.length ? `${filteredTable[0].type} ${type} ${game.i18n.localize("SWFFG.Triggered")} ${game.i18n.localize("SWFFG.For")} @Actor[${filteredTable[0].playerId}]{${filteredTable[0].name}}` : `${game.i18n.localize("SWFFG.OptionValueNo")} ${type} ${game.i18n.localize("SWFFG.Triggered")}`;
     let messageOptions = {
-      user: game.user.id,
+      author: game.user.id,
       content: tableResult,
     };
     if (game.settings.get("starwarsffg", "privateTriggers")) {

--- a/modules/helpers/character-creator.js
+++ b/modules/helpers/character-creator.js
@@ -1,3 +1,4 @@
+import EffectHelpers from "./effects.js";
 import ActorHelpers, {xpLogEarn, xpLogSpend} from "./actor-helpers.js";
 import DiceHelpers from "./dice-helpers.js";
 import {sortDataBy, addIfNotExist} from "../actors/actor-sheet-ffg.js";
@@ -1159,7 +1160,7 @@ export class CharacterCreator extends HandlebarsApplicationMixin(ApplicationV2) 
           name: `attr${nk}`,
           changes: [{
             key: `system.skills.${skillPurchase}.rank`,
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            ...EffectHelpers.changeType(),
             value: 1,
           }],
         };
@@ -1184,7 +1185,7 @@ export class CharacterCreator extends HandlebarsApplicationMixin(ApplicationV2) 
           name: `attr${nk}`,
           changes: [{
             key: `system.skills.${skillPurchase}.rank`,
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            ...EffectHelpers.changeType(),
             value: 1,
           }],
         };
@@ -1798,7 +1799,7 @@ export class CharacterCreator extends HandlebarsApplicationMixin(ApplicationV2) 
           name: `attr${nk}`,
           changes: [{
             key: `system.skills.${skillPurchase}.rank`,
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            ...EffectHelpers.changeType(),
             value: 1,
           }],
         };
@@ -1823,7 +1824,7 @@ export class CharacterCreator extends HandlebarsApplicationMixin(ApplicationV2) 
           name: `attr${nk}`,
           changes: [{
             key: `system.skills.${skillPurchase}.rank`,
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            ...EffectHelpers.changeType(),
             value: 1,
           }],
         };

--- a/modules/helpers/chat.js
+++ b/modules/helpers/chat.js
@@ -1,15 +1,17 @@
 /** Normalize the v13 roll modes and the v14 message modes at the system boundary. */
-const LEGACY_MODES = { publicroll: "roll", gmroll: "gm", blindroll: "blind", selfroll: "self" };
-const ROLL_MODES = { roll: "publicroll", gm: "gmroll", blind: "blindroll", self: "selfroll", ic: "publicroll", ooc: "publicroll" };
+const LEGACY_MODES = { publicroll: "public", gmroll: "gm", blindroll: "blind", selfroll: "self", ooc: "public" };
+const ROLL_MODES = { public: "publicroll", gm: "gmroll", blind: "blindroll", self: "selfroll", ic: "publicroll" };
 
 export function getMessageMode(options = {}) {
   const key = game.release.generation >= 14 ? "messageMode" : "rollMode";
-  const mode = options.messageMode ?? options.rollMode ?? game.settings.get("core", key);
+  let mode = options.messageMode ?? options.rollMode;
+  // The legacy "roll" value means the user's selected mode, not a public roll.
+  if (!mode || mode === "roll") mode = game.settings.get("core", key);
   return LEGACY_MODES[mode] ?? mode;
 }
 
 export function getRollMessageOptions(mode) {
-  const normalized = LEGACY_MODES[mode] ?? mode;
+  const normalized = getMessageMode({ messageMode: mode });
   return game.release.generation >= 14
     ? { messageMode: normalized }
     : { rollMode: ROLL_MODES[normalized] ?? normalized };

--- a/modules/helpers/chat.js
+++ b/modules/helpers/chat.js
@@ -1,0 +1,22 @@
+/** Normalize the v13 roll modes and the v14 message modes at the system boundary. */
+const LEGACY_MODES = { publicroll: "roll", gmroll: "gm", blindroll: "blind", selfroll: "self" };
+const ROLL_MODES = { roll: "publicroll", gm: "gmroll", blind: "blindroll", self: "selfroll", ic: "publicroll", ooc: "publicroll" };
+
+export function getMessageMode(options = {}) {
+  const key = game.release.generation >= 14 ? "messageMode" : "rollMode";
+  const mode = options.messageMode ?? options.rollMode ?? game.settings.get("core", key);
+  return LEGACY_MODES[mode] ?? mode;
+}
+
+export function getRollMessageOptions(mode) {
+  const normalized = LEGACY_MODES[mode] ?? mode;
+  return game.release.generation >= 14
+    ? { messageMode: normalized }
+    : { rollMode: ROLL_MODES[normalized] ?? normalized };
+}
+
+export function applyMessageMode(message, mode) {
+  const options = getRollMessageOptions(mode);
+  if (game.release.generation >= 14) message.applyMode(options.messageMode);
+  else message.applyRollMode(options.rollMode);
+}

--- a/modules/helpers/effects.js
+++ b/modules/helpers/effects.js
@@ -14,11 +14,13 @@ export default class EffectHelpers {
 
   // Map effects from EmbeddedCollection
   static transformEffects(originalEffect, _iterator, _effects) {
-    const effect = originalEffect.toObject();
+    const source = originalEffect.toObject();
+    // Make enumerable display fields instead of writing through v14's legacy shims.
+    const effect = { ...source, changes: source.system?.changes ?? source.changes ?? [] };
 
     // Copy properties we need from the prototype
     effect.id = originalEffect.id;
-    effect.parentName = originalEffect.parent.name;
+    effect.parentName = originalEffect.parent?.name;
     effect.active = originalEffect.active;
 
     // Convert duration to string
@@ -37,14 +39,13 @@ export default class EffectHelpers {
     }
 
     // Update each change from this effect
-    effect.changes.forEach((change, index) => {
+    effect.changes = effect.changes.map((change) => {
       // Convert mode to string
-      change.mode = change.type?.toUpperCase() ?? EffectHelpers.MODES[change.mode];
-
-      // LStrip 'system.' for shorter keys
-      if (change.key.startsWith("system.")) {
-        change.key = change.key.substring(7);
-      }
+      return {
+        ...change,
+        mode: change.type?.toUpperCase() ?? EffectHelpers.MODES[change.mode],
+        key: change.key?.startsWith("system.") ? change.key.substring(7) : change.key,
+      };
     });
 
     return effect;

--- a/modules/helpers/effects.js
+++ b/modules/helpers/effects.js
@@ -1,14 +1,20 @@
 export default class EffectHelpers {
 
   // Lookup mode name from int
-  static MODES = Object.fromEntries(
-    Object.entries(CONST.ACTIVE_EFFECT_MODES).map(
-      ([key, value]) => [value, key])
-    );
+  static get MODES() {
+    return { 0: "CUSTOM", 1: "MULTIPLY", 2: "ADD", 3: "DOWNGRADE", 4: "UPGRADE", 5: "OVERRIDE" };
+  }
+
+  /** Use string change types in v14, while retaining the v13 document format. */
+  static changeType(type = "add") {
+    return CONST.ACTIVE_EFFECT_CHANGE_TYPES
+      ? { type }
+      : { mode: CONST.ACTIVE_EFFECT_MODES[type.toUpperCase()] };
+  }
 
   // Map effects from EmbeddedCollection
   static transformEffects(originalEffect, _iterator, _effects) {
-    let effect = structuredClone(originalEffect);
+    const effect = originalEffect.toObject();
 
     // Copy properties we need from the prototype
     effect.id = originalEffect.id;
@@ -16,7 +22,9 @@ export default class EffectHelpers {
     effect.active = originalEffect.active;
 
     // Convert duration to string
-    if (effect.duration.combat) {
+    if (game.release.generation >= 14) {
+      effect.duration = originalEffect.duration.label;
+    } else if (effect.duration.combat) {
       effect.duration = game.i18n.localize("SWFFG.Effect.Duration.CurrentCombat");
     } else if (effect.duration.seconds) {
       effect.duration = `${effect.duration.seconds} ${game.i18n.localize("SWFFG.Effect.Duration.Seconds")}`;
@@ -31,7 +39,7 @@ export default class EffectHelpers {
     // Update each change from this effect
     effect.changes.forEach((change, index) => {
       // Convert mode to string
-      change.mode = EffectHelpers.MODES[change.mode];
+      change.mode = change.type?.toUpperCase() ?? EffectHelpers.MODES[change.mode];
 
       // LStrip 'system.' for shorter keys
       if (change.key.startsWith("system.")) {

--- a/modules/helpers/embeddeditem-helpers.js
+++ b/modules/helpers/embeddeditem-helpers.js
@@ -73,11 +73,11 @@ export default class EmbeddedItemHelpers {
     deleted_keys.forEach(function (cur_key) {
       cur_key = cur_key.substring(2);
       EmbeddedItemHelpers.removeKeyFromObject(
-          temporaryItem,
+          temporaryItem.system,
           cur_key,
       );
       EmbeddedItemHelpers.removeKeyFromObject(
-          realItem,
+          realItem?.system,
           cur_key,
       );
     });

--- a/modules/helpers/item-helpers.js
+++ b/modules/helpers/item-helpers.js
@@ -1,3 +1,4 @@
+import EffectHelpers from "./effects.js";
 import ModifierHelpers from "./modifiers.js";
 
 export default class ItemHelpers {
@@ -97,7 +98,7 @@ export default class ItemHelpers {
         }
         changes.push({
           key: path,
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          ...EffectHelpers.changeType(),
           value: true,
         });
       }
@@ -119,7 +120,7 @@ export default class ItemHelpers {
         }
         changes.push({
           key: path,
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          ...EffectHelpers.changeType(),
           value: true,
         });
       }
@@ -280,8 +281,7 @@ export default class ItemHelpers {
             CONFIG.logger.debug(`Located ${attr}, updating with new value of ${newValue}`);
             await matchingEffect.update({
               "changes": [{
-                key: matchingEffect.changes[0].key,
-                mode: matchingEffect.changes[0].mode,
+                ...matchingEffect.changes[0],
                 value: newValue,
               }],
             });

--- a/modules/helpers/modifiers.js
+++ b/modules/helpers/modifiers.js
@@ -1,3 +1,4 @@
+import EffectHelpers from "./effects.js";
 import PopoutModifiers from "../popout-modifiers.js";
 
 export default class ModifierHelpers {
@@ -734,7 +735,7 @@ export default class ModifierHelpers {
         for (const curMod of explodedMods) {
           changes.push({
             key: ModifierHelpers.getModKeyPath(curMod['modType'], curMod['mod']),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            ...EffectHelpers.changeType(),
             value: formData.data.attributes[k].value,
           });
         }

--- a/modules/helpers/modifiers.js
+++ b/modules/helpers/modifiers.js
@@ -610,6 +610,7 @@ export default class ModifierHelpers {
     const inherentEffectName = `(inherent)`;
     const inherentEffect = existing.find(e => e.name === inherentEffectName);
     if (inherentEffect && Object.keys(formData.data).includes("attributes")) {
+      const inherentChanges = foundry.utils.deepClone(inherentEffect.changes);
       for (let k of Object.keys(formData.data.attributes)) {
         if (k.startsWith("attr")) {
           // inherent effects like "brawn" on "species" only - skip user-created active effects only
@@ -626,13 +627,16 @@ export default class ModifierHelpers {
             curMod['modType'],
             curMod['mod']
           );
-          const inherentEffectChangeIndex = inherentEffect.changes.findIndex(c => c.key === modPath);
+          const inherentEffectChangeIndex = inherentChanges.findIndex(c => c.key === modPath);
           if (inherentEffectChangeIndex >= 0) {
-            inherentEffect.changes[inherentEffectChangeIndex].value = formData.data.attributes[k].value;
+            inherentChanges[inherentEffectChangeIndex].value = formData.data.attributes[k].value;
+          } else {
+            // A newly created species starts with no attributes until its first sheet edit.
+            inherentChanges.push({ key: modPath, ...EffectHelpers.changeType(), value: formData.data.attributes[k].value });
           }
         }
       }
-      await inherentEffect.update({changes: inherentEffect.changes});
+      await inherentEffect.update({changes: inherentChanges});
     }
     // some inherent effects are not in the `attribute` keyspace; make sure to get them as well
     if (inherentEffect && ["gear", "weapon", "armour"].includes(item.type)) {
@@ -764,8 +768,8 @@ export default class ModifierHelpers {
       const newBrawn = newChanges.find(ae => ae.key === "system.characteristics.Brawn.value").value;
       const newWillpower = newChanges.find(ae => ae.key === "system.characteristics.Willpower.value").value;
       // read the values from the form, if available, otherwise from the object
-      const wounds = formData?.data?.attributes?.Wounds?.value || item.system.attributes.Wounds.value;
-      const strain = formData?.data?.attributes?.Strain?.value || item.system.attributes.Strain.value;
+      const wounds = formData?.data?.attributes?.Wounds?.value ?? item.system.attributes.Wounds.value;
+      const strain = formData?.data?.attributes?.Strain?.value ?? item.system.attributes.Strain.value;
 
       for (const change of newChanges) {
         if (change.key === "system.stats.wounds.max") {

--- a/modules/helpers/tours.js
+++ b/modules/helpers/tours.js
@@ -1,3 +1,4 @@
+import EffectHelpers from "./effects.js";
 class CharacterTour extends foundry.nue.Tour {
   #originalDeactivate = null;
 
@@ -137,7 +138,7 @@ class EditModeTour extends foundry.nue.Tour {
     const AEData = {
       changes: [{
         key: "system.characteristics.Brawn.value",
-        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        ...EffectHelpers.changeType(),
         value: 3,
       }],
       name: "example",

--- a/modules/importer/import-helpers.js
+++ b/modules/importer/import-helpers.js
@@ -1,3 +1,4 @@
+import EffectHelpers from "../helpers/effects.js";
 import Helpers from "../helpers/common.js";
 import {migrateDataToSystem} from "../helpers/migration.js";
 import {ItemFFG} from "../items/item-ffg.js";
@@ -3056,7 +3057,7 @@ export default class ImportHelpers {
               );
               effects.changes.push({
                 key: path,
-                mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+                ...EffectHelpers.changeType(),
                 value: item.system.attributes[attribute].value,
               });
             }
@@ -3073,7 +3074,7 @@ export default class ImportHelpers {
             );
             effects.changes.push({
               key: path,
-              mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+              ...EffectHelpers.changeType(),
               value: 0,
             });
           }
@@ -3090,7 +3091,7 @@ export default class ImportHelpers {
               );
               effects.changes.push({
                 key: path,
-                mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+                ...EffectHelpers.changeType(),
                 value: 0,
               });
             }
@@ -3107,7 +3108,7 @@ export default class ImportHelpers {
             );
             effects.changes.push({
               key: path,
-              mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+              ...EffectHelpers.changeType(),
               value: 0,
             });
           }
@@ -3231,7 +3232,7 @@ export default class ImportHelpers {
         for (const curMod of explodedMods) {
           changes.push({
             key: ModifierHelpers.getModKeyPath(curMod['modType'], curMod['mod']),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            ...EffectHelpers.changeType(),
             value: formData.system.attributes[k].value,
           });
         }
@@ -3269,7 +3270,7 @@ export default class ImportHelpers {
         }
         changes.push({
           key: path,
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          ...EffectHelpers.changeType(),
           value: true,
         });
       }
@@ -3286,7 +3287,7 @@ export default class ImportHelpers {
         }
         changes.push({
           key: path,
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          ...EffectHelpers.changeType(),
           value: true,
         });
       }
@@ -3335,7 +3336,7 @@ export default class ImportHelpers {
             if (changeKey) {
               changes.push({
                 key: changeKey,
-                mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+                ...EffectHelpers.changeType(),
                 value: attribute.value,
               });
             }

--- a/modules/items/item-editor.js
+++ b/modules/items/item-editor.js
@@ -1,3 +1,4 @@
+import EffectHelpers from "../helpers/effects.js";
 import ItemHelpers from "../helpers/item-helpers.js";
 import ModifierHelpers from "../helpers/modifiers.js";
 
@@ -360,7 +361,7 @@ export class itemEditor extends FormApplication  {
               for (const curMod of explodedMods) {
                 changes.push({
                   key: ModifierHelpers.getModKeyPath(curMod['modType'], curMod['mod']),
-                  mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+                  ...EffectHelpers.changeType(),
                   value: formData.system.attributes[modKey].value,
                 });
               }
@@ -414,7 +415,7 @@ export class itemEditor extends FormApplication  {
                 for (const curMod of explodedMods) {
                   changes.push({
                     key: ModifierHelpers.getModKeyPath(curMod['modType'], curMod['mod']),
-                    mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+                    ...EffectHelpers.changeType(),
                     value: modifier.system.attributes[modKey].value,
                   });
                 }
@@ -506,7 +507,7 @@ export class itemEditor extends FormApplication  {
         for (const curMod of explodedMods) {
           changes.push({
             key: ModifierHelpers.getModKeyPath(curMod['modType'], curMod['mod']),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            ...EffectHelpers.changeType(),
             value: formData.system.attributes[modKey].value,
           });
         }
@@ -707,7 +708,7 @@ export class talentEditor extends itemEditor {
         for (const curMod of explodedMods) {
           changes.push({
             key: ModifierHelpers.getModKeyPath(curMod['modType'], curMod['mod']),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            ...EffectHelpers.changeType(),
             value: formData.attributes[modKey].value,
           });
         }
@@ -921,7 +922,7 @@ export class forcePowerEditor extends itemEditor {
         for (const curMod of explodedMods) {
           changes.push({
             key: ModifierHelpers.getModKeyPath(curMod['modType'], curMod['mod']),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            ...EffectHelpers.changeType(),
             value: formData.attributes[modKey].value,
           });
         }

--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -68,6 +68,9 @@ export class ItemFFG extends ItemBaseFFG {
     await super._onCreate(data, options, user);
 
     await this._onCreateAEs(options, force);
+    // Creation may not produce an equippable update when copied values are unchanged.
+    // Explicitly synchronize copied effects before the item is used by its Actor.
+    if (this.actor && this.system.equippable) await this._syncEquippedEffects();
   }
 
   async _onCreateAEs(options, force=false) {
@@ -245,16 +248,19 @@ export class ItemFFG extends ItemBaseFFG {
     }
 
     // handle equip / unequip by suspending / unsuspending AEs
-    const updatedExistingEffects = this.getEmbeddedCollection("ActiveEffect");
-    if (changed?.system?.equippable && updatedExistingEffects) {
-      const equipped = changed.system.equippable.equipped;
-      CONFIG.logger.debug("caught equip / unequip, checking if Active Effect state should be synced");
-      await ItemHelpers.syncAEStatus(this, updatedExistingEffects);
-      for (const effect of updatedExistingEffects) {
-        if (await ItemHelpers.shouldUpdateAEStatus(this, effect)) {
-          await ItemHelpers.updateEncumbranceOnEquip(this, effect, equipped);
-          await effect.update({disabled: !equipped});
-        }
+    if (changed?.system?.equippable) await this._syncEquippedEffects();
+  }
+
+  /** Keep copied and updated equipment effects aligned with the saved equip state. */
+  async _syncEquippedEffects() {
+    // Vehicle components are installed directly; their sheet has no equip toggle.
+    const equipped = this.actor?.type === "vehicle" || !!this.system.equippable.equipped;
+    const effects = this.getEmbeddedCollection("ActiveEffect");
+    await ItemHelpers.syncAEStatus(this, effects);
+    for (const effect of effects) {
+      if (await ItemHelpers.shouldUpdateAEStatus(this, effect)) {
+        await ItemHelpers.updateEncumbranceOnEquip(this, effect, equipped);
+        if (effect.disabled !== !equipped) await effect.update({disabled: !equipped});
       }
     }
   }
@@ -262,16 +268,17 @@ export class ItemFFG extends ItemBaseFFG {
   /**
    * Augment the basic Item data model with additional dynamic data.
    */
-  async prepareData() {
-    await super.prepareData();
+  prepareData() {
+    // Foundry prepares Documents synchronously, before taking sheet snapshots.
+    super.prepareData();
 
     // Get the Item's data
     const item = this;
-    const actor = this.actor ? this.actor : {};
+    const actor = this.actor ?? {};
     const data = item.system;
 
     if (!item.flags.starwarsffg) {
-      await item.updateSource({
+      item.updateSource({
         flags: {
           starwarsffg: {
             isCompendium: !!this.compendium,
@@ -299,7 +306,8 @@ export class ItemFFG extends ItemBaseFFG {
       }
     }
 
-    data.renderedDesc = await PopoutEditor.renderDiceImages(data.description, actor);
+    // Rich text enrichment is asynchronous and belongs in the sheet's getData.
+    data.renderedDesc = data.description;
 
     // perform localisation of dynamic values
     switch (this.type) {

--- a/modules/items/item-ffg.js
+++ b/modules/items/item-ffg.js
@@ -1,3 +1,4 @@
+import EffectHelpers from "../helpers/effects.js";
 import ItemBaseFFG from "./itembase-ffg.js";
 import PopoutEditor from "../popout-editor.js";
 import ActorOptions from "../actors/actor-ffg-options.js";
@@ -98,7 +99,7 @@ export class ItemFFG extends ItemBaseFFG {
               );
               effects.changes.push({
                 key: path,
-                mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+                ...EffectHelpers.changeType(),
                 value: this.system.attributes[attribute].value,
               });
             }
@@ -115,7 +116,7 @@ export class ItemFFG extends ItemBaseFFG {
             );
             effects.changes.push({
               key: path,
-              mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+              ...EffectHelpers.changeType(),
               value: 0,
             });
           }
@@ -132,7 +133,7 @@ export class ItemFFG extends ItemBaseFFG {
               );
               effects.changes.push({
                 key: path,
-                mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+                ...EffectHelpers.changeType(),
                 value: 0,
               });
             }
@@ -149,7 +150,7 @@ export class ItemFFG extends ItemBaseFFG {
             );
             effects.changes.push({
               key: path,
-              mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+              ...EffectHelpers.changeType(),
               value: 0,
             });
           }
@@ -157,7 +158,7 @@ export class ItemFFG extends ItemBaseFFG {
           for (let i = 0; i < 8; i++) {
             effects.changes.push({
               key: "(none)",
-              mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+              ...EffectHelpers.changeType(),
               value: true,
             });
           }
@@ -165,7 +166,7 @@ export class ItemFFG extends ItemBaseFFG {
           for (let i = 0; i < 5; i++) {
             effects.changes.push({
               key: "(none)",
-              mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+              ...EffectHelpers.changeType(),
               value: true,
             });
           }
@@ -228,7 +229,7 @@ export class ItemFFG extends ItemBaseFFG {
         for (const curMod of explodedMods) {
           changes.push({
             key: ModifierHelpers.getModKeyPath(curMod['modType'], curMod['mod']),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            ...EffectHelpers.changeType(),
             value: attr?.value,
           });
         }

--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -45,24 +45,25 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
   /** @override */
   async getData(options) {
     let data = super.getData(options);
+    // v14 exposes the live Item here. Enrich a copy so rendering does not
+    // mutate document data before update() can detect and persist edits.
+    data.item = this.item.toObject(false);
     // this code was mostly written by Phind
     // removing a key from a dict in Foundry requires submitting it with a new key of `-=key` and a value of null
     // without explicitly replacing values, we end up duplicating entries instead of removing the one
     // so instead, we go and manually remove any mods which have been deleted
 
-    // find any deleted attributes
+    // Search item data only: the v14 sheet context also contains live Documents
+    // whose parent/collection references are circular.
+    const itemSystem = data.item.system;
     const deleted_keys = EmbeddedItemHelpers.findKeysIncludingStringRecursively(
-        data,
+        itemSystem,
         '-=attr',
     );
     // remove matching attributes from the existing object
     deleted_keys.forEach(function (cur_key) {
       EmbeddedItemHelpers.removeKeyFromObject(
-        data,
-        cur_key,
-      );
-      EmbeddedItemHelpers.removeKeyFromObject(
-        data,
+        itemSystem,
         cur_key,
       );
     });
@@ -407,10 +408,8 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
       );
     }
 
-    data.renderedDesc = PopoutEditor.renderDiceImages(data.description, this.actor ? this.actor : {});
-    if (!data.renderedDesc) {
-      data.data.renderedDesc = PopoutEditor.renderDiceImages(data?.item?.system?.description, this.actor ? this.actor : {});
-    }
+    data.data.renderedDesc = await PopoutEditor.renderDiceImages(data.item.system.description, this.actor ?? {});
+    data.renderedDesc = data.data.renderedDesc;
 
     // get summarized data for qualities (e.g. weapons)
     data = this._getSummarizedQualities(data);
@@ -2012,6 +2011,7 @@ export class ItemSheetFFG extends foundry.appv1.sheets.ItemSheet {
       CONFIG.logger.debug(toCreate);
       const createdEffects = await this.object.createEmbeddedDocuments("ActiveEffect", toCreate);
       await ItemHelpers.syncAEStatus(this.object, createdEffects);
+      if (this.object.actor && this.object.system.equippable) await this.object._syncEquippedEffects();
     } else {
       CONFIG.logger.debug(`Rejected transferring AEs for drag-and-drop of ${droppedType} -> ${myType}`);
     }

--- a/modules/swffg-main.js
+++ b/modules/swffg-main.js
@@ -106,6 +106,18 @@ Hooks.once("init", async function () {
   CONFIG.Item.documentClass = ItemFFG;
   CONFIG.ActiveEffect.documentClass = ActiveEffectFFG;
 
+  if (game.release.generation >= 14) {
+    // Keep FFG's once/combat expiry alongside the core v14 effect changes.
+    CONFIG.ActiveEffect.dataModels.base = class extends foundry.data.ActiveEffectTypeDataModel {
+      static defineSchema() {
+        return {
+          ...super.defineSchema(),
+          duration: new foundry.data.fields.StringField({ required: false, nullable: true, initial: null }),
+        };
+      }
+    };
+  }
+
   // we do not want the legacy active effect transfer mode
   // also, reeeeeeeeeeeeeeeee
   if (game.release.generation < 14) CONFIG.ActiveEffect.legacyTransferral = false;
@@ -1009,8 +1021,12 @@ Hooks.on("renderChatInput", (app, html, data) => {
       rollButton.type = "button";
       rollButton.classList.add("ui-control", "icon", "fa-light", "fa-dice-d20");
 
-      const rollPrivacyElement = document.querySelector("#roll-privacy");
-      rollPrivacyElement.appendChild(rollButton);
+      rollButton.setAttribute("aria-label", game.i18n.localize("SWFFG.RollingDefaultTitle"));
+      const rollPrivacyElement = document.querySelector("#message-modes, #roll-privacy");
+      if (!rollPrivacyElement) return;
+      // v14's split-button controls message modes, so keep the dice button beside it.
+      if (game.release.generation >= 14) rollPrivacyElement.after(rollButton);
+      else rollPrivacyElement.appendChild(rollButton);
 
       rollButton.onclick = async function () {
         const dicePool = new DicePoolFFG();

--- a/modules/swffg-main.js
+++ b/modules/swffg-main.js
@@ -1,3 +1,4 @@
+import EffectHelpers from "./helpers/effects.js";
 /**
  * A systems implementation of the Star Wars RPG by Fantasy Flight Games.
  * Author: Esrin
@@ -107,7 +108,7 @@ Hooks.once("init", async function () {
 
   // we do not want the legacy active effect transfer mode
   // also, reeeeeeeeeeeeeeeee
-  CONFIG.ActiveEffect.legacyTransferral = false;
+  if (game.release.generation < 14) CONFIG.ActiveEffect.legacyTransferral = false;
 
   // Define custom Roll class
   CONFIG.Dice.rolls.push(CONFIG.Dice.rolls[0]);
@@ -685,22 +686,22 @@ Hooks.once("init", async function () {
     for (const skill of Object.keys(CONFIG.FFG.skills)) {
       allSkillChanges['boost'].push({
         key: `system.skills.${skill}.boost`,
-        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        ...EffectHelpers.changeType(),
         value: "1",
       });
       allSkillChanges['setback'].push({
         key: `system.skills.${skill}.setback`,
-        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        ...EffectHelpers.changeType(),
         value: "1",
       });
       allSkillChanges['upgrade'].push({
         key: `system.skills.${skill}.upgrades`,
-        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        ...EffectHelpers.changeType(),
         value: "1",
       });
       allSkillChanges['success'].push({
         key: `system.skills.${skill}.success`,
-        mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+        ...EffectHelpers.changeType(),
         value: "1",
       });
     }
@@ -758,12 +759,12 @@ Hooks.once("init", async function () {
       changes: [
         {
           key: "system.stats.defence.melee",
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          ...EffectHelpers.changeType(),
           value: "2",
         },
         {
           key: "system.stats.defence.ranged",
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          ...EffectHelpers.changeType(),
           value: "2",
         },
       ],
@@ -1085,12 +1086,13 @@ Hooks.on("renderCompendiumDirectory", (app, html, data) => {
 });
 
 // Update chat messages with dice images
-Hooks.on("renderChatMessage", async (app, html, messageData) => {
+Hooks.on("renderChatMessageHTML", async (message, element) => {
+  const html = $(element);
   const content = html.find(".message-content");
-  content[0].innerHTML = await PopoutEditor.renderDiceImages(content[0].innerHTML);
+  if (content.length) content[0].innerHTML = await PopoutEditor.renderDiceImages(content[0].innerHTML);
 
   html.on("click", ".ffg-pool-to-player", () => {
-    const poolData = messageData.message.flags.starwarsffg;
+    const poolData = message.flags.starwarsffg;
 
     const dicePool = new DicePoolFFG(poolData.dicePool);
 
@@ -1509,7 +1511,7 @@ Hooks.once("ready", async () => {
         CONFIG.FFG.DestinyGM = game.user.id;
 
         ChatMessage.create({
-          user: game.user.id,
+          author: game.user.id,
           content: messageText,
         });
       },

--- a/modules/swffg-migration.js
+++ b/modules/swffg-migration.js
@@ -1,3 +1,4 @@
+import EffectHelpers from "./helpers/effects.js";
 import ModifierHelpers from "./helpers/modifiers.js";
 
 /**
@@ -48,8 +49,8 @@ async function sendChanges(newVersion) {
   const template = "systems/starwarsffg/templates/notifications/new_version.html";
   const html = await foundry.applications.handlebars.renderTemplate(template, { version: newVersion });
   const messageData = {
-    user: game.user.id,
-    type: CONST.CHAT_MESSAGE_TYPES.OTHER,
+    author: game.user.id,
+    style: CONST.CHAT_MESSAGE_STYLES.OTHER,
     content: html,
   };
   ChatMessage.create(messageData);
@@ -62,8 +63,8 @@ async function sendChanges(newVersion) {
 async function warnTheme() {
   if (game.settings.get("starwarsffg", "ui-uitheme") === "default") {
     const messageData = {
-      user: game.user.id,
-      type: CONST.CHAT_MESSAGE_TYPES.OTHER,
+      author: game.user.id,
+      style: CONST.CHAT_MESSAGE_STYLES.OTHER,
       content: "You are using an unsupported theme. Expected issues, or swap to the Mandar theme.<br>(This message will only show once.)",
     };
     ChatMessage.create(messageData);
@@ -287,7 +288,7 @@ async function migrateTo1907() {
                   for (const curMod of explodedMods) {
                     changes.push({
                       key: ModifierHelpers.getModKeyPath(curMod['modType'], curMod['mod']),
-                      mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+                      ...EffectHelpers.changeType(),
                       value: item.system.talents[`talent${i}`].attributes[nk].value,
                     });
                   }
@@ -328,7 +329,7 @@ async function migrateTo1907() {
                   for (const curMod of explodedMods) {
                     changes.push({
                       key: ModifierHelpers.getModKeyPath(curMod['modType'], curMod['mod']),
-                      mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+                      ...EffectHelpers.changeType(),
                       value: item.system.upgrades[`upgrade${i}`].attributes[nk].value,
                     });
                   }
@@ -371,7 +372,7 @@ async function migrateTo1907() {
                   for (const curMod of explodedMods) {
                     changes.push({
                       key: ModifierHelpers.getModKeyPath(curMod['modType'], curMod['mod']),
-                      mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+                      ...EffectHelpers.changeType(),
                       value: item.system.upgrades[`upgrade${i}`].attributes[nk].value,
                     });
                   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "playwright": "^1.62.1"
       },
       "devDependencies": {
-        "@playwright/test": "^1.56.1",
+        "@playwright/test": "1.62.1",
         "@types/node": "^24.0.0",
         "cypress": "^15.18.0",
         "eslint": "^9.10.0",
@@ -333,63 +333,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.56.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.56.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@playwright/test": "^1.56.1",
+    "@playwright/test": "1.62.1",
     "@types/node": "^24.0.0",
     "cypress": "^15.18.0",
     "eslint": "^9.10.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "( PLEASE NOTE: This is a custom fork based on [Jaxxa's implementation](https://github.com/jaxxa/StarWarsFFG/tree/master). )",
   "main": "index.js",
   "scripts": {
+    "test:compat": "node --experimental-vm-modules --test tests/compatibility.test.mjs",
+    "test:e2e": "node node_modules/@playwright/test/cli.js test",
     "compile": "gulp css",
     "lint": "npx eslint modules",
     "watch": "gulp"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -21,7 +21,7 @@ if (fs.existsSync(envPath)) {
 }
 
 /* Base URL of the Foundry server under test - scheme, host and port, with no trailing path. */
-const baseURL = process.env.FOUNDRY_URL ?? 'http://localhost:30000';
+const baseURL = process.env.FOUNDRY_URL ?? 'http://localhost:30001';
 
 /**
  * @see https://playwright.dev/docs/test-configuration

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -59,11 +59,12 @@ export default defineConfig({
           height: 900
         },
         launchOptions: {
-          // force GPU acceleration
+          // WSL/CI may have no usable GPU. Use Chromium's software WebGL renderer.
           args: [
             '--ignore-gpu-blocklist',
             '--use-gl=angle',
-            '--use-angle=gl-egl',
+            '--use-angle=swiftshader',
+            '--enable-unsafe-swiftshader',
           ]
         },
       },

--- a/playwright/fixtures.ts
+++ b/playwright/fixtures.ts
@@ -387,10 +387,10 @@ export class Items {
       statName = 'defence';
     }
 
-    if (['defense', 'soak', 'encumbrance', 'hardpoints', 'rarity'].includes(statName)) {
+    if (['defence', 'soak', 'encumbrance', 'hardpoints', 'rarity'].includes(statName)) {
       await expect(this.sheetLocator.locator(`input[name="data.${statName}.value"]`)).toHaveValue(statValue);
     } else if (['Wounds', 'Strain', 'Brawn', 'Agility', 'Intellect', 'Cunning', 'Willpower', 'Presence'].includes(statName)) {
-      await this.sheetLocator.locator(`input[name="data.attributes.${statName}.value"]`).fill(statValue);
+      await expect(this.sheetLocator.locator(`input[name="data.attributes.${statName}.value"]`)).toHaveValue(statValue);
     }
   }
 

--- a/playwright/setup.ts
+++ b/playwright/setup.ts
@@ -10,41 +10,40 @@ async function globalSetup(config: FullConfig) {
   }
   // TODO: this should probably be done before each test instead of globally
   // this will allow us to use specific accounts for each test, and in turn run tests in parallel
-  const { baseURL, storageState } = config.projects[0].use;
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  /*
-  await page.goto(baseURL!);
-  await page.getByLabel('User Name').fill('user');
-  await page.getByLabel('Password').fill('password');
-  await page.getByText('Sign in').click();
-  await page.context().storageState({ path: storageState as string });
-  await browser.close();
+  const { baseURL, storageState, launchOptions } = config.projects[0].use;
+  const browser = await chromium.launch(launchOptions);
+  try {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    page.on('pageerror', error => console.error('Foundry startup error:', error.stack));
+    // globalSetup drives its own browser, so it does not get the config's baseURL applied
+    // automatically the way tests do - build the absolute URL from it here.
+    await page.goto(new URL('/join', baseURL).href);
+    // Validate before joining: a GM login can itself start system data migrations.
+    await expect(page.locator('#main-header h1')).toHaveText(expectedTitle);
+    await expect(page.locator('#software-version')).toContainText(new RegExp(`Version ${expectedGeneration}\\b`));
+    if (expectedGeneration >= 14) {
+      await page.getByRole('textbox', { name: 'Select User', exact: true }).click();
+      await page.getByRole('listitem').filter({ hasText: /^Gamemaster$/ }).click();
+      await page.getByRole('button', { name: 'Join Game Session', exact: true }).click();
+    } else {
+      await page.locator('#join-game-form select[name="userid"]').selectOption({ label: 'Gamemaster' });
+      await page.locator('#join-game-form button[name="join"]').click();
+    }
+    await expect(page.locator('#chat-message')).toBeVisible();
+    // the destiny tracker only exists once the system itself has booted, so it doubles as a "world is
+    // ready" signal. Assert on the element rather than its text, which changes with the destiny pool.
+    await expect(page.locator('#destinyDark')).toBeVisible({ timeout: 30_000 });
 
-  */
-  // globalSetup drives its own browser, so it does not get the config's baseURL applied
-  // automatically the way tests do - build the absolute URL from it here.
-  await page.goto(new URL('/join', baseURL).href);
-  // Validate before joining: a GM login can itself start system data migrations.
-  await expect(page.locator('#main-header h1')).toHaveText(expectedTitle);
-  await expect(page.locator('#software-version')).toContainText(new RegExp(`Version ${expectedGeneration}\\b`));
-  // v13 renders the join screen as an ApplicationV2 into #join-game-form. The user <select> holds
-  // user IDs as option values, so the user has to be picked by its visible label.
-  await page.locator('#join-game-form select[name="userid"]').selectOption({ label: 'Gamemaster' });
-  await page.locator('#join-game-form button[name="join"]').click();
-  await expect(page.getByRole('textbox', { name: 'Chat' })).toBeVisible();
-  // the destiny tracker only exists once the system itself has booted, so it doubles as a "world is
-  // ready" signal. Assert on the element rather than its text, which changes with the destiny pool.
-  await expect(page.locator('#destinyDark')).toBeVisible({ timeout: 30_000 });
+    const loaded = await page.evaluate(() => {
+      const game = (window as any).game;
+      return { world: game.world.id, system: game.system.id, generation: game.release.generation, isGM: game.user.isGM };
+    });
+    expect(loaded).toEqual({ world: expectedWorld, system: 'starwarsffg', generation: expectedGeneration, isGM: true });
 
-  const loaded = await page.evaluate(() => {
-    const game = (window as any).game;
-    return { world: game.world.id, system: game.system.id, generation: game.release.generation };
-  });
-  expect(loaded).toEqual({ world: expectedWorld, system: 'starwarsffg', generation: expectedGeneration });
-
-  await page.context().storageState({ path: storageState as string });
-  await browser.close();
+    await page.context().storageState({ path: storageState as string });
+  } finally {
+    await browser.close();
+  }
 }
 
 export default globalSetup;

--- a/playwright/setup.ts
+++ b/playwright/setup.ts
@@ -2,6 +2,12 @@
 import {chromium, expect, type FullConfig} from '@playwright/test';
 
 async function globalSetup(config: FullConfig) {
+  const expectedWorld = process.env.FOUNDRY_TEST_WORLD;
+  const expectedTitle = process.env.FOUNDRY_TEST_WORLD_TITLE;
+  const expectedGeneration = Number(process.env.FOUNDRY_TEST_GENERATION ?? 14);
+  if (!expectedWorld || !expectedTitle || ![13, 14].includes(expectedGeneration)) {
+    throw new Error('Configure FOUNDRY_TEST_WORLD, FOUNDRY_TEST_WORLD_TITLE and FOUNDRY_TEST_GENERATION for a disposable test world before running browser tests.');
+  }
   // TODO: this should probably be done before each test instead of globally
   // this will allow us to use specific accounts for each test, and in turn run tests in parallel
   const { baseURL, storageState } = config.projects[0].use;
@@ -19,6 +25,9 @@ async function globalSetup(config: FullConfig) {
   // globalSetup drives its own browser, so it does not get the config's baseURL applied
   // automatically the way tests do - build the absolute URL from it here.
   await page.goto(new URL('/join', baseURL).href);
+  // Validate before joining: a GM login can itself start system data migrations.
+  await expect(page.locator('#main-header h1')).toHaveText(expectedTitle);
+  await expect(page.locator('#software-version')).toContainText(new RegExp(`Version ${expectedGeneration}\\b`));
   // v13 renders the join screen as an ApplicationV2 into #join-game-form. The user <select> holds
   // user IDs as option values, so the user has to be picked by its visible label.
   await page.locator('#join-game-form select[name="userid"]').selectOption({ label: 'Gamemaster' });
@@ -27,6 +36,12 @@ async function globalSetup(config: FullConfig) {
   // the destiny tracker only exists once the system itself has booted, so it doubles as a "world is
   // ready" signal. Assert on the element rather than its text, which changes with the destiny pool.
   await expect(page.locator('#destinyDark')).toBeVisible({ timeout: 30_000 });
+
+  const loaded = await page.evaluate(() => {
+    const game = (window as any).game;
+    return { world: game.world.id, system: game.system.id, generation: game.release.generation };
+  });
+  expect(loaded).toEqual({ world: expectedWorld, system: 'starwarsffg', generation: expectedGeneration });
 
   await page.context().storageState({ path: storageState as string });
   await browser.close();

--- a/system.json
+++ b/system.json
@@ -6,7 +6,7 @@
   "compatibility": {
     "minimum": 13,
     "verified": 13,
-    "maximum": 13
+    "maximum": 14
   },
   "authors": [{"name": "Esrin"}, {"name": "CStadther"}, {"name": "Wrycu"}, {"name": "Jaxxa"}],
   "esmodules": ["modules/dice-pool-ffg.js", "modules/swffg-main.js", "lib/slimselect/slimselect.js", "lib/datatables/datatables.min.js"],

--- a/tests/compatibility.test.mjs
+++ b/tests/compatibility.test.mjs
@@ -12,13 +12,15 @@ async function loadSystem(generation = 14, defaultMode = "blind") {
     constructor(data) { this.data = { whisper: [], blind: false, ...data }; }
     applyMode(mode) {
       assert.equal(generation, 14, "v13 must use applyRollMode");
+      assert.ok(['public', 'ic', 'gm', 'blind', 'self'].includes(mode), 'must pass a registered v14 message mode');
       this.setVisibility(mode);
     }
     applyRollMode(mode) {
       assert.equal(generation, 13, "v14 must use applyMode");
-      this.setVisibility({ publicroll: "roll", gmroll: "gm", blindroll: "blind", selfroll: "self" }[mode]);
+      this.setVisibility({ publicroll: "public", gmroll: "gm", blindroll: "blind", selfroll: "self" }[mode]);
     }
     setVisibility(mode) {
+      if (mode === 'public') this.data.whisper = [];
       if (["gm", "blind"].includes(mode)) this.data.whisper = ["gm-id"];
       if (mode === "self") this.data.whisper = ["player-id"];
       this.data.blind = mode === "blind";
@@ -85,7 +87,8 @@ test('v14 uses the saved blind mode without reading the removed core.rollMode se
 });
 
 for (const [mode, recipients, blind] of [
-  ['gm', ['gm-id'], false], ['blind', ['gm-id'], true], ['self', ['player-id'], false], ['roll', [], false],
+  ['gm', ['gm-id'], false], ['blind', ['gm-id'], true], ['self', ['player-id'], false], ['public', [], false],
+  ['publicroll', [], false], ['roll', ['gm-id'], true],
   ['gmroll', ['gm-id'], false], ['blindroll', ['gm-id'], true], ['selfroll', ['player-id'], false],
 ]) {
   test(`v14 publishes ${mode} with the intended recipients`, async () => {
@@ -117,6 +120,23 @@ test('v13 still uses its saved private roll mode', async () => {
   assert.deepEqual(settingsRead, ['core.rollMode']);
 });
 
+test('explicit public rolls override a saved blind mode and existing whisper recipients', async () => {
+  for (const generation of [13, 14]) {
+    const { roll } = await loadSystem(generation, generation === 14 ? 'blind' : 'blindroll');
+    const data = await roll.toMessage({ whisper: ['gm-id'] }, { rollMode: 'publicroll', create: false });
+    assert.deepEqual(data.whisper, []);
+    assert.equal(data.blind, false);
+  }
+});
+
+test('the legacy roll sentinel respects the saved private mode in both generations', async () => {
+  for (const generation of [13, 14]) {
+    const { roll } = await loadSystem(generation, generation === 14 ? 'self' : 'selfroll');
+    const data = await roll.toMessage({}, { rollMode: 'roll', create: false });
+    assert.deepEqual(data.whisper, ['player-id']);
+  }
+});
+
 test('private obligation rolls supply the appropriate core Roll option in both generations', async () => {
   for (const generation of [13, 14]) {
     const { chat } = await loadSystem(generation);
@@ -136,15 +156,41 @@ test('new effects use the modern type field, with the legacy format retained on 
 test('v14 effect display uses prepared duration text without mutating the original change', async () => {
   const { effects } = await loadSystem();
   const source = { name: 'Defense', duration: { units: 'rounds', value: 2 },
-    changes: [{ key: 'system.stats.defence.ranged', type: 'add', phase: 'base', priority: 20, value: '1' }] };
+    system: { changes: [{ key: 'system.stats.defence.ranged', type: 'add', phase: 'initial', priority: 20, value: '1' }] } };
   const document = { id: 'effect-id', parent: { name: 'Armor' }, active: true,
     duration: { label: '2 rounds' }, toObject: () => structuredClone(source) };
   const display = effects.transformEffects(document);
   assert.equal(display.duration, '2 rounds');
   assert.equal(display.changes[0].mode, 'ADD');
   assert.equal(display.changes[0].key, 'stats.defence.ranged');
-  assert.equal(source.changes[0].key, 'system.stats.defence.ranged');
-  assert.equal(source.changes[0].mode, undefined);
-  assert.equal(display.changes[0].phase, 'base');
+  assert.equal(source.system.changes[0].key, 'system.stats.defence.ranged');
+  assert.equal(source.system.changes[0].mode, undefined);
+  assert.equal(display.changes[0].phase, 'initial');
   assert.equal(display.changes[0].priority, 20);
+});
+
+test('the final effect phase does not count initial Force Rating bonuses a second time', async () => {
+  class ActorStub {
+    applyActiveEffects(phase) { this.phases.push(phase); }
+  }
+  const context = vm.createContext({ Actor: ActorStub });
+  const module = new vm.SourceTextModule(await readFile(new URL('../modules/actors/actor-ffg.js', import.meta.url), 'utf8'), { context });
+  await module.link(() => new vm.SyntheticModule(['default'], function () {
+    this.setExport('default', class {});
+  }, { context }));
+  await module.evaluate();
+  const actor = new module.namespace.ActorFFG();
+  actor.phases = [];
+  actor.system = { stats: { forcePool: { max: 2, value: 1 } } };
+  const skillChange = { key: 'system.skills.Discipline.force', value: 0 };
+  actor.allApplicableEffects = () => [
+    { active: true, changes: [{ key: 'system.stats.forcePool.max', value: 1 }, skillChange] },
+    { active: false, changes: [{ key: 'system.stats.forcePool.max', value: 5 }] },
+  ];
+  actor.applyActiveEffects('initial');
+  assert.equal(skillChange.value, 2, 'only active bonuses, minus committed dice');
+  actor.system.stats.forcePool.max = 3; // Core has now applied the initial bonus.
+  actor.applyActiveEffects('final');
+  assert.equal(skillChange.value, 2, 'final preparation must not add the same bonus again');
+  assert.deepEqual(actor.phases, ['initial', 'final'], 'both phases still reach core');
 });

--- a/tests/compatibility.test.mjs
+++ b/tests/compatibility.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import vm from "node:vm";
+
+// Exercise the real system modules without requiring a licensed Foundry server.
+// The stubs implement the external document boundary; browser tests still validate core integration.
+async function loadSystem(generation = 14, defaultMode = "blind") {
+  const created = [];
+  const settingsRead = [];
+  class ChatMessageStub {
+    constructor(data) { this.data = { whisper: [], blind: false, ...data }; }
+    applyMode(mode) {
+      assert.equal(generation, 14, "v13 must use applyRollMode");
+      this.setVisibility(mode);
+    }
+    applyRollMode(mode) {
+      assert.equal(generation, 13, "v14 must use applyMode");
+      this.setVisibility({ publicroll: "roll", gmroll: "gm", blindroll: "blind", selfroll: "self" }[mode]);
+    }
+    setVisibility(mode) {
+      if (["gm", "blind"].includes(mode)) this.data.whisper = ["gm-id"];
+      if (mode === "self") this.data.whisper = ["player-id"];
+      this.data.blind = mode === "blind";
+    }
+    toObject() { return { ...this.data }; }
+    static async create(data) { created.push(data); return data; }
+  }
+  class RollStub {
+    constructor() { this.terms = []; this.data = {}; this._evaluated = false; }
+    get total() { return this._total; }
+  }
+  const context = vm.createContext({
+    game: {
+      release: { generation },
+      user: { id: "player-id" },
+      settings: { get(scope, key) {
+        settingsRead.push(`${scope}.${key}`);
+        assert.equal(key, generation === 14 ? "messageMode" : "rollMode");
+        return defaultMode;
+      } },
+    },
+    CONFIG: { sounds: { dice: "dice.ogg" } },
+    CONST: generation === 14
+      ? { ACTIVE_EFFECT_CHANGE_TYPES: { add: 20 } }
+      : { ACTIVE_EFFECT_MODES: { ADD: 2 } },
+    foundry: { utils: { mergeObject: (base, extra) => ({ ...base, ...extra }) } },
+    Roll: RollStub,
+    getDocumentClass: () => ChatMessageStub,
+    Hooks: { call() {} },
+  });
+  const chat = new vm.SourceTextModule(await readFile(new URL('../modules/helpers/chat.js', import.meta.url), 'utf8'), { context });
+  await chat.link(() => { throw new Error('Unexpected chat helper import'); });
+  await chat.evaluate();
+  const effects = new vm.SourceTextModule(await readFile(new URL('../modules/helpers/effects.js', import.meta.url), 'utf8'), { context });
+  await effects.link(() => { throw new Error('Unexpected effect helper import'); });
+  await effects.evaluate();
+  const rollModule = new vm.SourceTextModule(await readFile(new URL('../modules/dice/roll.js', import.meta.url), 'utf8'), { context });
+  await rollModule.link(async (specifier) => {
+    if (specifier === '../helpers/chat.js') return chat;
+    const stub = new vm.SyntheticModule(['default', 'ForceDie', 'migrateDataToSystem', 'ItemFFG'], function () {
+      this.setExport('default', class {});
+      this.setExport('ForceDie', class {});
+      this.setExport('migrateDataToSystem', data => data);
+      this.setExport('ItemFFG', class {});
+    }, { context });
+    return stub;
+  });
+  await rollModule.evaluate();
+  const roll = new rollModule.namespace.RollFFG();
+  roll._evaluated = true;
+  roll._total = 2;
+  return { roll, created, settingsRead, chat: chat.namespace, effects: effects.namespace.default };
+}
+
+test('v14 uses the saved blind mode without reading the removed core.rollMode setting', async () => {
+  const { roll, created, settingsRead } = await loadSystem();
+  const data = await roll.toMessage({}, { create: false });
+  assert.deepEqual(settingsRead, ['core.messageMode']);
+  assert.deepEqual(data.whisper, ['gm-id']);
+  assert.equal(data.blind, true);
+  assert.equal(data.author, 'player-id');
+  assert.equal(created.length, 0, 'create:false must not publish an initiative message');
+  assert.equal(data.rolls[0], roll);
+});
+
+for (const [mode, recipients, blind] of [
+  ['gm', ['gm-id'], false], ['blind', ['gm-id'], true], ['self', ['player-id'], false], ['roll', [], false],
+  ['gmroll', ['gm-id'], false], ['blindroll', ['gm-id'], true], ['selfroll', ['player-id'], false],
+]) {
+  test(`v14 publishes ${mode} with the intended recipients`, async () => {
+    const { roll, created } = await loadSystem();
+    await roll.toMessage({}, { messageMode: mode });
+    assert.equal(created.length, 1);
+    assert.deepEqual(created[0].whisper, recipients);
+    assert.equal(created[0].blind, blind);
+  });
+}
+
+test('explicit message mode overrides legacy options and the saved default', async () => {
+  const { roll, settingsRead } = await loadSystem();
+  const data = await roll.toMessage({ user: 'macro-author', rollMode: 'blindroll', flavor: 'Initiative' },
+    { messageMode: 'self', rollMode: 'gmroll', create: false });
+  assert.deepEqual(data.whisper, ['player-id']);
+  assert.equal(data.author, 'macro-author');
+  assert.equal(data.flavor, 'Initiative');
+  assert.equal('user' in data, false);
+  assert.equal('rollMode' in data, false);
+  assert.equal('messageMode' in data, false);
+  assert.deepEqual(settingsRead, []);
+});
+
+test('v13 still uses its saved private roll mode', async () => {
+  const { roll, settingsRead } = await loadSystem(13, 'gmroll');
+  const data = await roll.toMessage({}, { create: false });
+  assert.deepEqual(data.whisper, ['gm-id']);
+  assert.deepEqual(settingsRead, ['core.rollMode']);
+});
+
+test('private obligation rolls supply the appropriate core Roll option in both generations', async () => {
+  for (const generation of [13, 14]) {
+    const { chat } = await loadSystem(generation);
+    const options = JSON.parse(JSON.stringify(chat.getRollMessageOptions('gm')));
+    assert.deepEqual(options, generation === 14 ? { messageMode: 'gm' } : { rollMode: 'gmroll' });
+  }
+});
+
+test('new effects use the modern type field, with the legacy format retained on v13', async () => {
+  for (const generation of [13, 14]) {
+    const { effects } = await loadSystem(generation);
+    const change = JSON.parse(JSON.stringify(effects.changeType()));
+    assert.deepEqual(change, generation === 14 ? { type: 'add' } : { mode: 2 });
+  }
+});
+
+test('v14 effect display uses prepared duration text without mutating the original change', async () => {
+  const { effects } = await loadSystem();
+  const source = { name: 'Defense', duration: { units: 'rounds', value: 2 },
+    changes: [{ key: 'system.stats.defence.ranged', type: 'add', phase: 'base', priority: 20, value: '1' }] };
+  const document = { id: 'effect-id', parent: { name: 'Armor' }, active: true,
+    duration: { label: '2 rounds' }, toObject: () => structuredClone(source) };
+  const display = effects.transformEffects(document);
+  assert.equal(display.duration, '2 rounds');
+  assert.equal(display.changes[0].mode, 'ADD');
+  assert.equal(display.changes[0].key, 'stats.defence.ranged');
+  assert.equal(source.changes[0].key, 'system.stats.defence.ranged');
+  assert.equal(source.changes[0].mode, undefined);
+  assert.equal(display.changes[0].phase, 'base');
+  assert.equal(display.changes[0].priority, 20);
+});


### PR DESCRIPTION
## Adaptation de StarWarsFFG à Foundry VTT 14.367

Cette migration adapte StarWarsFFG aux API de Foundry VTT 14.367, avec une couche de compatibilité pour les anciennes options de jets et les formats utilisés sous v13.

### 1. Jets de dés et API du chat

- Adaptation de la création des `ChatMessage` aux champs `author` et `style`, avec utilisation de `CONST.CHAT_MESSAGE_STYLES`.
- Ajout d’une normalisation entre les options v13 et v14 :
  - v13 : `rollMode` et `applyRollMode()`.
  - v14 : `messageMode` et `applyMode()`.
- Conversion des valeurs historiques `publicroll`, `gmroll`, `blindroll` et `selfroll` vers les modes correspondants.
- Conservation du comportement historique de la valeur `roll`, qui utilise le mode enregistré dans les préférences de l’utilisateur.
- Correction de `RollFFG.toMessage()` pour que `{ create: false }` retourne des données sérialisables, en conservant les jets, l’auteur et les paramètres de confidentialité. Ce comportement est notamment utilisé pour les messages d’initiative.
- Migration du hook de rendu vers `renderChatMessageHTML`, avec adaptation de son `HTMLElement` aux gestionnaires jQuery existants.
- Repositionnement du bouton de dés près des contrôles v14 `#message-modes`.
- Utilisation de `foundry.audio.AudioHelper` pour la lecture audio.

### 2. Format, application et durée des effets actifs

- Centralisation du format des modifications dans `EffectHelpers.changeType()` :
  - Changements typés sous v14, par exemple `{ type: "add" }`.
  - Conservation des modes numériques sous v13.
- Préservation des métadonnées `type`, `phase` et `priority` lors des mises à jour de rang.
- Adaptation de `ActorFFG.applyActiveEffects(phase)` pour transmettre la phase au traitement natif.
- Limitation du calcul spécifique des bonus de Force à la phase initiale, en ignorant les effets inactifs. Cela évite leur double comptabilisation lors de la phase finale.
- Préparation de l’affichage depuis une copie des données `system.changes` et du libellé `duration.label`, sans écrire dans les anciens accesseurs de compatibilité.
- Extension de `foundry.data.ActiveEffectTypeDataModel` pour conserver le champ spécifique `system.duration`. Les valeurs `once` et `combat` survivent ainsi à l’enregistrement et restent exploitables par les mécanismes d’expiration du système.

### 3. Préparation des documents et rendu des fiches

- Rétablissement d’un `ItemFFG.prepareData()` synchrone, conformément au cycle de préparation des documents Foundry.
- Déplacement de l’enrichissement asynchrone des descriptions dans les méthodes `getData()` des fiches.
- Préparation des valeurs calculées et de la visibilité des éléments des arbres de talents avant la construction du contexte de rendu.
- Utilisation d’une copie produite par `toObject(false)` pour préparer l’affichage des fiches d’objets.
- Limitation du nettoyage récursif des attributs aux données `system`, afin d’éviter les références circulaires des instances `Document` et les mutations involontaires pendant le rendu.

### 4. Équipement, accessoires et effets transférés

- Ajout de `_syncEquippedEffects()` pour synchroniser les effets après :
  - La création d’un objet.
  - Une modification de son état d’équipement.
  - Le transfert d’effets depuis un accessoire.
- Synchronisation des effets concernés avec l’état équipé/déséquipé du personnage.
- Traitement des composants des véhicules comme installés, leurs fiches ne proposant pas le même mécanisme d’équipement.
- Lors d’un dépôt d’objet sur un acteur, conservation des valeurs ajustées de l’objet et copie de ses effets depuis leurs données sources. Cela évite de persister les durées permanentes préparées sous forme d’`Infinity` en v14.
- Correction des effets inhérents des nouvelles espèces : création des modifications manquantes lors de la première édition et conservation des valeurs explicitement définies à zéro.

### 5. Combat, initiative et points de destin

- Conversion des modes publics `public` et `ic` en mode `gm` pour les initiatives des combattants cachés, tout en préservant les modes déjà privés.
- Récupération des effets du tracker via `actor.temporaryEffects` et de leurs images via `effect.img`, en remplacement des anciens accès aux effets des tokens.
- Adaptation des interactions de destin au hook `renderChatMessageHTML`.
- Vérification, avec deux sessions indépendantes, des demandes de jet de destin, de la dépense des points et de la synchronisation des réserves entre joueur et MJ.

### 6. Tests et environnement de validation

- **18 tests isolés réussis**, couvrant les adaptations d’API, les modes de message et les formats d’effets à l’aide d’interfaces Foundry simulées.
- **27 tests d’intégration réussis dans Foundry 14.367** :
  - 16 scénarios d’effets existants.
  - 11 scénarios supplémentaires couvrant les dés, la sérialisation, les fiches, la persistance, la confidentialité après rechargement, le combat et le destin.
- Validation de la suite complète contre l’archive installée du système.
- Environnement de test :
  - Node.js **24.15.0**.
  - Playwright **1.62.1**.
  - Chromium **151**.
  - Rendu WebGL logiciel pour WSL.
- Vérification explicite de l’identité du monde de test au démarrage des tests automatisés.
- **Compilation Sass réussie.**
- ESLint : **119 erreurs et 464 avertissements**, contre 119 erreurs et 466 avertissements initialement. Aucune nouvelle erreur détectée, mais le lint global du projet reste en échec.

### 7. Migration des données et statut de compatibilité

Une copie d’un monde sous Foundry **13.351** a terminé sa migration native vers **14.367**, compendiums concernés compris, sans erreur serveur relevée pendant cette opération.

Les validations suivantes restent à terminer :

- [x] Initialisation du monde migré après connexion MJ.
- [ ] Vérification des fiches existantes et de la persistance des modifications.
- [ ] Contrôle des importeurs.
- [ ] Vérification des intégrations avec les modules optionnels.

Le manifeste conserve les valeurs suivantes :

- `minimum: 13`
- `verified: 13`
- `maximum: 14`

La v14 est autorisée pour les tests de développement. La compatibilité complète n’est pas encore déclarée.